### PR TITLE
VIRTS1536: Replaced cairo with svglib/lxml

### DIFF
--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -30,9 +30,11 @@ class DebriefGui(BaseWorld):
         self.file_svc = services.get('file_svc')
         self.log = logging.getLogger('debrief_gui')
 
-        # suppress Python Image Library debug logs
+        # suppress Python Image Library and svglib debug logs
         pil = logging.getLogger('PIL')
         pil.setLevel(logging.INFO)
+        svglib = logging.getLogger('svglib')
+        svglib.setLevel(logging.INFO)
 
     async def _get_access(self, request):
         return dict(access=tuple(await self.auth_svc.get_permissions(request)))

--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -30,11 +30,8 @@ class DebriefGui(BaseWorld):
         self.file_svc = services.get('file_svc')
         self.log = logging.getLogger('debrief_gui')
 
-        # suppress Python Image Library and svglib debug logs
-        pil = logging.getLogger('PIL')
-        pil.setLevel(logging.INFO)
-        svglib = logging.getLogger('svglib')
-        svglib.setLevel(logging.INFO)
+        self._suppress_logs('PIL')
+        self._suppress_logs('svglib')
 
     async def _get_access(self, request):
         return dict(access=tuple(await self.auth_svc.get_permissions(request)))
@@ -160,3 +157,8 @@ class DebriefGui(BaseWorld):
         imgs.extend(glob.glob('./plugins/debrief/downloads/*.svg'))
         for f in imgs:
             os.remove(f)
+
+    @staticmethod
+    def _suppress_logs(library):
+        lib = logging.getLogger(library)
+        lib.setLevel(logging.INFO)

--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -1,5 +1,4 @@
 import base64
-import cairosvg
 import glob
 import logging
 import os
@@ -68,7 +67,7 @@ class DebriefGui(BaseWorld):
     async def download_pdf(self, request):
         data = dict(await request.json())
         svg_data = data['graphs']
-        self._svgs_to_pngs(svg_data)
+        self._save_svgs(svg_data)
         if data['operations']:
             operations = [o for o in await self.data_svc.locate('operations', match=await self._get_access(request))
                           if str(o.id) in data.get('operations')]
@@ -118,7 +117,7 @@ class DebriefGui(BaseWorld):
 
         story_obj.append_text('OPERATIONS GRAPHS', styles['Heading2'], 0)
         graph_files = dict()
-        for file in glob.glob('./plugins/debrief/downloads/*.png'):
+        for file in glob.glob('./plugins/debrief/downloads/*.svg'):
             graph_files[os.path.basename(file).split('.')[0]] = file
         story_obj.append_graph('graph', graph_files['graph'])
         story_obj.append_graph('tactic', graph_files['tactic'])
@@ -146,13 +145,11 @@ class DebriefGui(BaseWorld):
         return pdf_value.decode('utf-8', errors='ignore')
 
     @staticmethod
-    def _svgs_to_pngs(svgs):
+    def _save_svgs(svgs):
         for filename, svg_bytes in svgs.items():
             save_location = './plugins/debrief/downloads/'
             with open(save_location + filename + '.svg', "wb") as fh:
                 fh.write(base64.b64decode(svg_bytes))
-            cairosvg.svg2png(url=save_location + filename + '.svg',
-                             write_to=save_location + filename + '.png')
 
     @staticmethod
     def _clean_downloads():

--- a/app/objects/c_story.py
+++ b/app/objects/c_story.py
@@ -1,9 +1,9 @@
 import base64
 from reportlab.lib import colors
-from reportlab.lib import utils
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.units import inch
 from reportlab.platypus import Paragraph, Spacer, Table, TableStyle, PageBreak, Image
+from svglib.svglib import svg2rlg
 
 
 class Story:
@@ -49,15 +49,15 @@ class Story:
 
     def append_graph(self, name, path):
         styles = getSampleStyleSheet()
-        graph = self._get_image(path, width=4*inch)
-        if name == 'tactic':
-            graph._restrictSize(2 * inch, 1 * inch)
         if name == 'graph':
             self.append_text('Operations Graph', styles['Heading3'], 12)
         else:
             self.append_text('%s Graph' % name.capitalize(), styles['Heading3'], 0)
         self.append_text(self.get_description(name), styles['Normal'], 12)
-        self.append(graph)
+
+        graph = svg2rlg(path)
+        aspect = graph.height / float(graph.width)
+        self.append(Image(graph, width=4*inch, height=(4*inch * aspect)))
 
     def generate_op_steps(self, operation):
         steps = [['Time', 'Status', 'Agent', 'Name', 'Command', 'Facts']]
@@ -125,13 +125,6 @@ class Story:
 
         # Release the canvas
         canvas.restoreState()
-
-    @staticmethod
-    def _get_image(path, width=1 * inch):
-        img = utils.ImageReader(path)
-        iw, ih = img.getSize()
-        aspect = ih / float(iw)
-        return Image(path, width=width, height=(width * aspect))
 
     @staticmethod
     def _status_name(status):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-cairosvg==2.4.2
+lxml==4.5.2
 reportlab==3.5.49
+svglib==1.0.1


### PR DESCRIPTION
Replaced cairo/cairosvg dependency with svglib (main functionality used was the `svg2rlg` function).

svglib is missing functionality for scaling SVGs according to their `preserveAspectRatio`, the reason I had searched for an alternative library in the first place since this caused the icons to be stretched. This was resolved by using the `lxml` library to manually alter the `width` attribute in the XML based on the svg `viewBox`, effectively resizing the inner SVGs appropriately and maintaining the aspect ratio.