### PR TITLE
VIRTS1550: Fact graph clean up

### DIFF
--- a/app/objects/c_story.py
+++ b/app/objects/c_story.py
@@ -194,7 +194,8 @@ class Story:
         elif obj == 'fact':
             return 'This graph displays the facts discovered by the operations run. Facts are attached to the ' \
                    'operation where they were discovered. Facts are also attached to the facts that led to their ' \
-                   'discovery.'
+                   'discovery. For readability, only the first 15 facts discovered in an operation are included in ' \
+                   'the graph.'
         elif obj == 'tactic':
             return 'This graph displays the order of tactics executed by the operation. A tactic explains the ' \
                    'general purpose or the "why" of a step.'

--- a/static/css/debrief.css
+++ b/static/css/debrief.css
@@ -113,3 +113,28 @@ li.legend {
     width: 165px;
     background-color: rgba(155, 155, 155, .6);
 }
+.fact-count {
+    font-weight: bold;
+}
+
+#fact-limit-msg {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    border-radius: 20px 20px 0 0;
+    display: none;
+    background-color: rgba(255, 0, 0, 0.5);
+    text-align: center;
+
+}
+
+#fact-count {
+    position: absolute;
+    top: 150px;
+    right: 20px;
+    padding: 20px;
+    border-spacing: 5px;
+    color: white;
+    font-size: 13px;
+}

--- a/static/js/debrief.js
+++ b/static/js/debrief.js
@@ -25,6 +25,8 @@ $( document ).ready(function() {
             updateReportGraph(operations);
             $('.debrief-display-opt').prop("checked", true);
             $("#show-tactic-icons").prop("checked", false);
+            $("#fact-limit-msg").hide();
+            $("#fact-limit-msg p").html();
             restRequest('POST', {'operations': operations}, displayReport, '/plugin/debrief/report');
         }
     });

--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -1,3 +1,5 @@
+var factDisplayLimit = 15;
+
 class Graph {
     constructor(id, type, tooltip) {
         this.id = id;
@@ -133,6 +135,10 @@ function buildGraph(graphObj, operations) {
         if (error) throw error;
         console.log(graph);
         writeGraph(graph, graphObj);
+        if (graphObj.type == "fact") {
+            updateFactCounts(graph);
+            limitFactsDisplayed(operations);
+        }
     });
 }
 
@@ -335,4 +341,42 @@ function statusColor(status) {
         return '#EE3377';
     }
     return '#555555';
+}
+
+function updateFactCounts(graph) {
+    let factCounts = getFactCounts(graph);
+    $("#fact-count").empty();
+    for (var fact in factCounts) {
+        let rowData = "<td class='fact-count'>" + factCounts[fact] + "</td><td>" + fact + "</td>";
+        $("#fact-count").append($("<tr>" + rowData + "</tr>"));
+    }
+}
+
+function getFactCounts(graph) {
+    let factDict = {};
+    for (var i in graph['nodes']) {
+        let fact = graph['nodes'][i];
+        if (fact.type == 'fact') {
+            if (fact.name in factDict) {
+                factDict[fact.name] += 1;
+            }
+            else {
+                factDict[fact.name] = 1;
+            }
+        }
+    }
+    return factDict;
+}
+
+function limitFactsDisplayed(operations) {
+    console.log(operations)
+    let hasOverFactLimit = operations.some(function(op) { return $("#debrief-fact-svg g.fact[data-op='" + op + "']").slice(factDisplayLimit).length > 0 })
+    if (hasOverFactLimit) {
+        $("#fact-limit-msg p").html("More than " + factDisplayLimit + " facts found in the operation(s) selected. For readability, only the first " + factDisplayLimit + " facts of each operation are displayed.");
+        $("#fact-limit-msg").show();
+        operations.forEach(function(opId) {
+            $("#debrief-fact-svg g.fact[data-op='" + opId + "']").slice(factDisplayLimit).remove();
+            $("#debrief-fact-svg line.relationship[data-source='" + opId + "']").slice(factDisplayLimit).remove();
+        })
+    }
 }

--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -369,7 +369,6 @@ function getFactCounts(graph) {
 }
 
 function limitFactsDisplayed(operations) {
-    console.log(operations)
     let hasOverFactLimit = operations.some(function(op) { return $("#debrief-fact-svg g.fact[data-op='" + op + "']").slice(factDisplayLimit).length > 0 })
     if (hasOverFactLimit) {
         $("#fact-limit-msg p").html("More than " + factDisplayLimit + " facts found in the operation(s) selected. For readability, only the first " + factDisplayLimit + " facts of each operation are displayed.");

--- a/templates/debrief.html
+++ b/templates/debrief.html
@@ -89,10 +89,14 @@
             </div>
             <h3>Fact Graph</h3>
             <div id="fact-graph" class="row svg-container" style="background-color: black; height: 400px; background-image: none;">
+                <div id="fact-limit-msg">
+                    <p style="margin: 0;"></p>
+                </div>
                 <div id="fact-legend" class="legend-box">
                     <h4>Legend</h4>
                     <ul id="fact-legend-list"  style="padding: 0px; margin: 0px"></ul>
                 </div>
+                <table id="fact-count"></table>
                 <div class="d3-tooltip" id="fact-tooltip" style="opacity: 0"></div>
                 <svg id="debrief-fact-svg" class="debrief-svg"></svg>
             </div>


### PR DESCRIPTION
- Limits max facts displayed to 15 facts per graph by removing D3 nodes past the max cap
- Lists number of facts below the legend

Future:
- Minor display issue causing excessive jitter/force on the remaining fact nodes
- Capability to select/filter specific facts