### PR TITLE
bug fix: removed old fact legend from HTML

### DIFF
--- a/templates/debrief.html
+++ b/templates/debrief.html
@@ -116,10 +116,6 @@
                 <div id="fact-limit-msg">
                     <p style="margin: 0;"></p>
                 </div>
-                <div id="fact-legend" class="legend-box">
-                    <h4>Legend</h4>
-                    <ul id="fact-legend-list"  style="padding: 0px; margin: 0px"></ul>
-                </div>
                 <table id="fact-count"></table>
                 <div class="d3-tooltip" id="fact-tooltip" style="opacity: 0"></div>
                 <svg id="debrief-fact-svg" class="debrief-svg"></svg>


### PR DESCRIPTION
Not sure how this was still in master, I thought it had been removed with the new legends