### PR TITLE
Report Section Modules, Section Reordering, and Header upload

### DIFF
--- a/app/debrief-sections/agents.py
+++ b/app/debrief-sections/agents.py
@@ -1,0 +1,26 @@
+from plugins.debrief.app.utility.base_report_section import BaseReportSection
+
+
+class DebriefReportSection(BaseReportSection):
+    def __init__(self):
+        super().__init__()
+        self.id = 'agents'
+        self.display_name = 'Agents'
+        self.section_title = 'AGENTS'
+        self.description = 'The table below displays information about the agents used. An agent\'s paw is the unique' \
+                           ' identifier, or paw print, of an agent. Also included are the username of the user who ' \
+                           'executed the agent, the privilege level of the agent process, and the name of the agent ' \
+                           'executable.'
+
+    def generate_section_elements(self, styles, **kwargs):
+        flowable_list = []
+        if 'agents' in kwargs:
+            flowable_list.append(self.generate_section_title_and_description(styles))
+            agent_data = [['Paw', 'Host', 'Platform', 'Username', 'Privilege', 'Executable']]
+            for a in kwargs.get('agents', []):
+                agent_data.append(
+                    ['<a name="agent-{0}"/>{0}'.format(a.paw), a.host, a.platform, a.username, a.privilege,
+                     a.exe_name])
+            flowable_list.append(self.generate_table(agent_data, '*'))
+
+        return flowable_list

--- a/app/debrief-sections/fact_graph.py
+++ b/app/debrief-sections/fact_graph.py
@@ -9,7 +9,7 @@ class DebriefReportSection(BaseReportSection):
         super().__init__()
         self.id = 'fact-graph'
         self.display_name = 'Fact Graph'
-        self.section_title = 'Fact Graph'
+        self.section_title = 'FACT GRAPH'
         self.description = 'This graph displays the facts discovered by the operations run. Facts are attached to ' \
                            'the operation where they were discovered. Facts are also attached to the facts that led ' \
                            'to their discovery. For readability, only the first 15 facts discovered in an operation ' \
@@ -17,13 +17,9 @@ class DebriefReportSection(BaseReportSection):
 
     def generate_section_elements(self, styles, **kwargs):
         flowable_list = []
-        if 'graph_files' in kwargs:
-            graph_files = kwargs.get('graph_files', {})
-            flowable_list.append(self.generate_section_title_and_description(styles))
-            flowable_list.append(Spacer(1, 12))
-
-            path = graph_files.get('fact')
-            if path:
-                flowable_list.append(self.generate_graph(path, 4*inch))
+        path = kwargs.get('graph_files', {}).get('fact')
+        if path:
+            # Keep the title, description, and graph grouped together to avoid page break in the middle.
+            flowable_list.append(self.generate_grouped_graph_section_flowables(styles, path, 4*inch))
 
         return flowable_list

--- a/app/debrief-sections/fact_graph.py
+++ b/app/debrief-sections/fact_graph.py
@@ -1,0 +1,29 @@
+from reportlab.lib.units import inch
+from reportlab.platypus import Spacer
+
+from plugins.debrief.app.utility.base_report_section import BaseReportSection
+
+
+class DebriefReportSection(BaseReportSection):
+    def __init__(self):
+        super().__init__()
+        self.id = 'fact-graph'
+        self.display_name = 'Fact Graph'
+        self.section_title = 'Fact Graph'
+        self.description = 'This graph displays the facts discovered by the operations run. Facts are attached to ' \
+                           'the operation where they were discovered. Facts are also attached to the facts that led ' \
+                           'to their discovery. For readability, only the first 15 facts discovered in an operation ' \
+                           'are included in the graph.'
+
+    def generate_section_elements(self, styles, **kwargs):
+        flowable_list = []
+        if 'graph_files' in kwargs:
+            graph_files = kwargs.get('graph_files', {})
+            flowable_list.append(self.generate_section_title_and_description(styles))
+            flowable_list.append(Spacer(1, 12))
+
+            path = graph_files.get('fact')
+            if path:
+                flowable_list.append(self.generate_graph(path, 4*inch))
+
+        return flowable_list

--- a/app/debrief-sections/facts_table.py
+++ b/app/debrief-sections/facts_table.py
@@ -1,0 +1,43 @@
+from reportlab.lib.units import inch
+from reportlab.platypus import Paragraph
+from reportlab.platypus.flowables import KeepTogetherSplitAtTop
+
+from plugins.debrief.app.utility.base_report_section import BaseReportSection
+
+
+class DebriefReportSection(BaseReportSection):
+    def __init__(self):
+        super().__init__()
+        self.id = 'facts-table'
+        self.display_name = 'Operation Facts Table'
+        self.section_title = 'FACTS FOUND IN OPERATION <font name=Courier-Bold size=17>%s</font>'
+        self.description = 'The table below displays the facts found in the operation, the command run and the agent ' \
+                           'that found the fact. Every fact, by default, gets a score of 1. If a host.user.password ' \
+                           'fact is important or has a high chance of success if used, you may assign it a score of ' \
+                           '5. When an ability uses a fact to fill in a variable, it will use those with the highest ' \
+                           'scores first. A fact with a score of 0, is blacklisted - meaning it cannot be used in ' \
+                           'an operation.'
+
+    def generate_section_elements(self, styles, **kwargs):
+        flowable_list = []
+        if 'operations' in kwargs:
+            operations = kwargs.get('operations', [])
+            for o in operations:
+                flowable_list.append(
+                    KeepTogetherSplitAtTop([
+                        Paragraph(self.section_title % o.name.upper(), styles['Heading2']),
+                        Paragraph(self.description, styles['Normal'])
+                    ])
+                )
+                flowable_list.append(self._generate_facts_table(o))
+        return flowable_list
+
+    def _generate_facts_table(self, operation):
+        fact_data = [['Trait', 'Value', 'Score', 'Paw', 'Command Run']]
+        for lnk in operation.chain:
+            if len(lnk.facts) > 0:
+                for f in lnk.facts:
+                    fact_data.append([f.trait, f.value, str(f.score),
+                                      '<link href="#agent-{0}" color="blue">{0}</link>'.format(lnk.paw),
+                                      lnk.decode_bytes(lnk.command)])
+        return self.generate_table(fact_data, [1 * inch, 1.2 * inch, .6 * inch, .6 * inch, 3 * inch])

--- a/app/debrief-sections/main_summary.py
+++ b/app/debrief-sections/main_summary.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from reportlab.platypus import Paragraph, Spacer
+from reportlab.platypus.flowables import KeepTogetherSplitAtTop
+
+from plugins.debrief.app.utility.base_report_section import BaseReportSection
+
+
+class DebriefReportSection(BaseReportSection):
+    def __init__(self):
+        super().__init__()
+        self.id = 'main-summary'
+        self.display_name = 'Main Summary'
+        self.section_title = 'OPERATIONS DEBRIEF'
+        self.description = 'This document covers the overall campaign analytics made up of the selected set of ' \
+                           'operations. The below sections contain general metadata about the selected operations ' \
+                           'as well as graphical views of the operations, the techniques and tactics used, and the ' \
+                           'facts discovered by the operations. The following sections include a more in depth ' \
+                           'review of each specific operation ran.'
+
+    def generate_section_elements(self, styles, **kwargs):
+        title = styles['Heading1']
+        title.fontName = 'VeraBd'
+        title.textColor = 'maroon'
+        title.fontSize = 24
+        timestamp = "<i>Generated on %s</i>" % datetime.today().strftime('%Y-%m-%d %H:%M:%S')
+        return [
+            KeepTogetherSplitAtTop([
+                Paragraph(self.section_title, title),
+                Spacer(1, 6),
+                Paragraph(timestamp, styles['Normal']),
+                Spacer(1, 12),
+                Paragraph(self.description, styles['Normal'])
+            ])
+        ]

--- a/app/debrief-sections/operations_graph.py
+++ b/app/debrief-sections/operations_graph.py
@@ -1,4 +1,5 @@
 from reportlab.lib.units import inch
+from reportlab.platypus import Paragraph
 
 from plugins.debrief.app.utility.base_report_section import BaseReportSection
 
@@ -8,17 +9,15 @@ class DebriefReportSection(BaseReportSection):
         super().__init__()
         self.id = 'default-graph'
         self.display_name = 'Operations Graph'
-        self.section_title = 'Operations Graph'
+        self.section_title = 'OPERATIONS GRAPH'
         self.description = 'This is a graphical display of the agents connected to the command and control (C2), the ' \
                            'operations run, and the steps of each operation as they relate to the agents.'
 
     def generate_section_elements(self, styles, **kwargs):
         flowable_list = []
-        if 'graph_files' in kwargs:
-            graph_files = kwargs.get('graph_files', {})
-            flowable_list.append(self.generate_section_title_and_description(styles))
-            path = graph_files.get('graph')
-            if path:
-                flowable_list.append(self.generate_graph(path, 4*inch))
+        path = kwargs.get('graph_files', {}).get('graph')
+        if path:
+            # Keep the title, description, and graph grouped together to avoid page break in the middle.
+            flowable_list.append(self.generate_grouped_graph_section_flowables(styles, path, 4*inch))
 
         return flowable_list

--- a/app/debrief-sections/operations_graph.py
+++ b/app/debrief-sections/operations_graph.py
@@ -1,0 +1,27 @@
+from reportlab.lib.units import inch
+from reportlab.platypus import Spacer
+
+from plugins.debrief.app.utility.base_report_section import BaseReportSection
+
+
+class DebriefReportSection(BaseReportSection):
+    def __init__(self):
+        super().__init__()
+        self.id = 'default-graph'
+        self.display_name = 'Operations Graph'
+        self.section_title = 'Operations Graph'
+        self.description = 'This is a graphical display of the agents connected to the command and control (C2), the ' \
+                           'operations run, and the steps of each operation as they relate to the agents.'
+
+    def generate_section_elements(self, styles, **kwargs):
+        flowable_list = []
+        if 'graph_files' in kwargs:
+            graph_files = kwargs.get('graph_files', {})
+            flowable_list.append(self.generate_section_title_and_description(styles))
+            flowable_list.append(Spacer(1, 12))
+
+            path = graph_files.get('tactic')
+            if path:
+                flowable_list.append(self.generate_graph(path, 4*inch))
+
+        return flowable_list

--- a/app/debrief-sections/operations_graph.py
+++ b/app/debrief-sections/operations_graph.py
@@ -1,5 +1,4 @@
 from reportlab.lib.units import inch
-from reportlab.platypus import Spacer
 
 from plugins.debrief.app.utility.base_report_section import BaseReportSection
 
@@ -18,9 +17,7 @@ class DebriefReportSection(BaseReportSection):
         if 'graph_files' in kwargs:
             graph_files = kwargs.get('graph_files', {})
             flowable_list.append(self.generate_section_title_and_description(styles))
-            flowable_list.append(Spacer(1, 12))
-
-            path = graph_files.get('tactic')
+            path = graph_files.get('graph')
             if path:
                 flowable_list.append(self.generate_graph(path, 4*inch))
 

--- a/app/debrief-sections/statistics.py
+++ b/app/debrief-sections/statistics.py
@@ -1,0 +1,31 @@
+from reportlab.platypus import Spacer
+
+from plugins.debrief.app.utility.base_report_section import BaseReportSection
+
+
+class DebriefReportSection(BaseReportSection):
+    def __init__(self):
+        super().__init__()
+        self.id = 'statistics'
+        self.display_name = 'Statistics'
+        self.section_title = 'STATISTICS'
+        self.description = 'An operation\'s planner makes up the decision making process. It contains logic for how ' \
+                           'a running operation should make decisions about which abilities to use and in what order.' \
+                           ' An objective is a collection of fact targets, called goals, which can be tied to ' \
+                           'adversaries. During the course of an operation, every time the planner is evaluated, the ' \
+                           'current objective status is evaluated in light of the current knowledge of the ' \
+                           'operation, with the operation completing should all goals be met.'
+
+    def generate_section_elements(self, styles, **kwargs):
+        flowable_list = []
+        if 'operations' in kwargs:
+            operations = kwargs.get('operations', [])
+            flowable_list.append(self.generate_section_title_and_description(styles))
+            flowable_list.append(Spacer(1, 12))
+            data = [['Name', 'State', 'Planner', 'Objective', 'Time']]
+            for o in operations:
+                finish = o.finish if o.finish else 'Not finished'
+                data.append([o.name, o.state, o.planner.name, o.objective.name, finish])
+            flowable_list.append(self.generate_table(data, '*'))
+
+        return flowable_list

--- a/app/debrief-sections/statistics.py
+++ b/app/debrief-sections/statistics.py
@@ -1,5 +1,3 @@
-from reportlab.platypus import Spacer
-
 from plugins.debrief.app.utility.base_report_section import BaseReportSection
 
 
@@ -21,7 +19,6 @@ class DebriefReportSection(BaseReportSection):
         if 'operations' in kwargs:
             operations = kwargs.get('operations', [])
             flowable_list.append(self.generate_section_title_and_description(styles))
-            flowable_list.append(Spacer(1, 12))
             data = [['Name', 'State', 'Planner', 'Objective', 'Time']]
             for o in operations:
                 finish = o.finish if o.finish else 'Not finished'

--- a/app/debrief-sections/steps_table.py
+++ b/app/debrief-sections/steps_table.py
@@ -1,0 +1,39 @@
+from reportlab.lib.units import inch
+from reportlab.platypus import Paragraph
+from reportlab.platypus.flowables import KeepTogetherSplitAtTop
+
+from plugins.debrief.app.utility.base_report_section import BaseReportSection
+
+
+class DebriefReportSection(BaseReportSection):
+    def __init__(self):
+        super().__init__()
+        self.id = 'steps-table'
+        self.display_name = 'Steps Table'
+        self.section_title = 'STEPS IN OPERATION <font name=Courier-Bold size=17>%s</font>'
+        self.description = 'The table below shows detailed information about the steps taken in an operation and ' \
+                           'whether the command run discovered any facts.'
+
+    def generate_section_elements(self, styles, **kwargs):
+        flowable_list = []
+        if 'operations' in kwargs:
+            operations = kwargs.get('operations', [])
+            for o in operations:
+                flowable_list.append(
+                    KeepTogetherSplitAtTop([
+                        Paragraph(self.section_title % o.name.upper(), styles['Heading2']),
+                        Paragraph(self.description, styles['Normal'])
+                    ])
+                )
+                flowable_list.append(self._generate_op_steps_table(o))
+        return flowable_list
+
+    def _generate_op_steps_table(self, operation):
+        steps = [['Time', 'Status', 'Agent', 'Name', 'Command', 'Facts']]
+        for link in operation.chain:
+            steps.append(
+                [link.finish or '', self.status_name(link.status), link.paw, link.ability.name,
+                 link.decode_bytes(link.command),
+                 'Yes' if len([f for f in link.facts if f.score > 0]) > 0 else 'No'])
+
+        return self.generate_table(steps, [.75 * inch, .6 * inch, .6 * inch, .85 * inch, 3 * inch, .6 * inch])

--- a/app/debrief-sections/tactic_graph.py
+++ b/app/debrief-sections/tactic_graph.py
@@ -18,8 +18,6 @@ class DebriefReportSection(BaseReportSection):
         if 'graph_files' in kwargs:
             graph_files = kwargs.get('graph_files', {})
             flowable_list.append(self.generate_section_title_and_description(styles))
-            flowable_list.append(Spacer(1, 12))
-
             path = graph_files.get('tactic')
             if path:
                 flowable_list.append(self.generate_graph(path, 4*inch))

--- a/app/debrief-sections/tactic_graph.py
+++ b/app/debrief-sections/tactic_graph.py
@@ -1,5 +1,5 @@
 from reportlab.lib.units import inch
-from reportlab.platypus import Spacer
+from reportlab.platypus import Paragraph
 
 from plugins.debrief.app.utility.base_report_section import BaseReportSection
 
@@ -9,17 +9,15 @@ class DebriefReportSection(BaseReportSection):
         super().__init__()
         self.id = 'tactic-graph'
         self.display_name = 'Tactic Graph'
-        self.section_title = 'Tactic Graph'
+        self.section_title = 'TACTIC GRAPH'
         self.description = 'This graph displays the order of tactics executed by the operation. A tactic explains ' \
                            'the general purpose or the "why" of a step.'
 
     def generate_section_elements(self, styles, **kwargs):
         flowable_list = []
-        if 'graph_files' in kwargs:
-            graph_files = kwargs.get('graph_files', {})
-            flowable_list.append(self.generate_section_title_and_description(styles))
-            path = graph_files.get('tactic')
-            if path:
-                flowable_list.append(self.generate_graph(path, 4*inch))
+        path = kwargs.get('graph_files', {}).get('tactic')
+        if path:
+            # Keep the title, description, and graph grouped together to avoid page break in the middle.
+            flowable_list.append(self.generate_grouped_graph_section_flowables(styles, path, 4*inch))
 
         return flowable_list

--- a/app/debrief-sections/tactic_graph.py
+++ b/app/debrief-sections/tactic_graph.py
@@ -1,0 +1,27 @@
+from reportlab.lib.units import inch
+from reportlab.platypus import Spacer
+
+from plugins.debrief.app.utility.base_report_section import BaseReportSection
+
+
+class DebriefReportSection(BaseReportSection):
+    def __init__(self):
+        super().__init__()
+        self.id = 'tactic-graph'
+        self.display_name = 'Tactic Graph'
+        self.section_title = 'Tactic Graph'
+        self.description = 'This graph displays the order of tactics executed by the operation. A tactic explains ' \
+                           'the general purpose or the "why" of a step.'
+
+    def generate_section_elements(self, styles, **kwargs):
+        flowable_list = []
+        if 'graph_files' in kwargs:
+            graph_files = kwargs.get('graph_files', {})
+            flowable_list.append(self.generate_section_title_and_description(styles))
+            flowable_list.append(Spacer(1, 12))
+
+            path = graph_files.get('tactic')
+            if path:
+                flowable_list.append(self.generate_graph(path, 4*inch))
+
+        return flowable_list

--- a/app/debrief-sections/tactic_technique_table.py
+++ b/app/debrief-sections/tactic_technique_table.py
@@ -1,4 +1,6 @@
 from reportlab.lib.units import inch
+from reportlab.platypus import Paragraph
+from reportlab.platypus.flowables import KeepTogetherSplitAtTop
 
 from plugins.debrief.app.utility.base_report_section import BaseReportSection
 
@@ -9,16 +11,17 @@ class DebriefReportSection(BaseReportSection):
         self.id = 'tactic-technique-table'
         self.display_name = 'Tactic and Technique Table'
         self.section_title = 'TACTICS AND TECHNIQUES'
-        self.description = 'The table below shows detailed information about the steps taken in an operation and ' \
-                           'whether the command run discovered any facts.'
+        self.description = ''
 
     def generate_section_elements(self, styles, **kwargs):
         flowable_list = []
         if 'operations' in kwargs:
             operations = kwargs.get('operations', [])
             ttps = self._get_operation_ttps(operations)
-            flowable_list.append(self.generate_section_title_and_description(styles))
-            flowable_list.append(self._generate_ttps_table(ttps))
+            flowable_list.append(KeepTogetherSplitAtTop([
+                Paragraph(self.section_title, styles['Heading2']),
+                self._generate_ttps_table(ttps)
+            ]))
         return flowable_list
 
     def _generate_ttps_table(self, ttps):

--- a/app/debrief-sections/tactic_technique_table.py
+++ b/app/debrief-sections/tactic_technique_table.py
@@ -1,0 +1,52 @@
+from reportlab.lib.units import inch
+
+from plugins.debrief.app.utility.base_report_section import BaseReportSection
+
+
+class DebriefReportSection(BaseReportSection):
+    def __init__(self):
+        super().__init__()
+        self.id = 'tactic-technique-table'
+        self.display_name = 'Tactic and Technique Table'
+        self.section_title = 'TACTICS AND TECHNIQUES'
+        self.description = 'The table below shows detailed information about the steps taken in an operation and ' \
+                           'whether the command run discovered any facts.'
+
+    def generate_section_elements(self, styles, **kwargs):
+        flowable_list = []
+        if 'operations' in kwargs:
+            operations = kwargs.get('operations', [])
+            ttps = self._get_operation_ttps(operations)
+            flowable_list.append(self.generate_section_title_and_description(styles))
+            flowable_list.append(self._generate_ttps_table(ttps))
+        return flowable_list
+
+    def _generate_ttps_table(self, ttps):
+        ttp_data = [['Tactics', 'Techniques', 'Abilities']]
+        for key, tactic in ttps.items():
+            technique_arr = []
+            for name, tid in tactic['techniques'].items():
+                technique_arr.append(tid + ': ' + name)
+            ttp_data.append([tactic['name'].capitalize(), technique_arr, tactic['steps']])
+        return self.generate_table(ttp_data, [1.25 * inch, 3.25 * inch, 2 * inch])
+
+    @staticmethod
+    def _get_operation_ttps(operations):
+        ttps = dict()
+        for op in operations:
+            for link in op.chain:
+                if not link.cleanup:
+                    tactic_name = link.ability.tactic
+                    if tactic_name not in ttps.keys():
+                        tactic = dict(name=tactic_name,
+                                      techniques={link.ability.technique_name: link.ability.technique_id},
+                                      steps={op.name: [link.ability.name]})
+                        ttps[tactic_name] = tactic
+                    else:
+                        if link.ability.technique_name not in ttps[tactic_name]['techniques'].keys():
+                            ttps[tactic_name]['techniques'][link.ability.technique_name] = link.ability.technique_id
+                        if op.name not in ttps[tactic_name]['steps'].keys():
+                            ttps[tactic_name]['steps'][op.name] = [link.ability.name]
+                        elif link.ability.name not in ttps[tactic_name]['steps'][op.name]:
+                            ttps[tactic_name]['steps'][op.name].append(link.ability.name)
+        return dict(sorted(ttps.items()))

--- a/app/debrief-sections/tactic_technique_table.py
+++ b/app/debrief-sections/tactic_technique_table.py
@@ -1,8 +1,8 @@
 from reportlab.lib.units import inch
 from reportlab.platypus import Paragraph
-from reportlab.platypus.flowables import KeepTogetherSplitAtTop
 
 from plugins.debrief.app.utility.base_report_section import BaseReportSection
+from plugins.debrief.app.debrief_svc import DebriefService
 
 
 class DebriefReportSection(BaseReportSection):
@@ -17,8 +17,8 @@ class DebriefReportSection(BaseReportSection):
         flowable_list = []
         if 'operations' in kwargs:
             operations = kwargs.get('operations', [])
-            ttps = self._get_operation_ttps(operations)
-            flowable_list.append(KeepTogetherSplitAtTop([
+            ttps = DebriefService.generate_ttps(operations)
+            flowable_list.append(self.group_elements([
                 Paragraph(self.section_title, styles['Heading2']),
                 self._generate_ttps_table(ttps)
             ]))

--- a/app/debrief-sections/technique_graph.py
+++ b/app/debrief-sections/technique_graph.py
@@ -18,8 +18,6 @@ class DebriefReportSection(BaseReportSection):
         if 'graph_files' in kwargs:
             graph_files = kwargs.get('graph_files', {})
             flowable_list.append(self.generate_section_title_and_description(styles))
-            flowable_list.append(Spacer(1, 12))
-
             path = graph_files.get('technique')
             if path:
                 flowable_list.append(self.generate_graph(path, 4*inch))

--- a/app/debrief-sections/technique_graph.py
+++ b/app/debrief-sections/technique_graph.py
@@ -1,0 +1,27 @@
+from reportlab.lib.units import inch
+from reportlab.platypus import Spacer
+
+from plugins.debrief.app.utility.base_report_section import BaseReportSection
+
+
+class DebriefReportSection(BaseReportSection):
+    def __init__(self):
+        super().__init__()
+        self.id = 'technique-graph'
+        self.display_name = 'Technique Graph'
+        self.section_title = 'Technique Graph'
+        self.description = 'This graph displays the order of techniques executed by the operation. A technique ' \
+                           'explains the technical method or the "how" of a step.'
+
+    def generate_section_elements(self, styles, **kwargs):
+        flowable_list = []
+        if 'graph_files' in kwargs:
+            graph_files = kwargs.get('graph_files', {})
+            flowable_list.append(self.generate_section_title_and_description(styles))
+            flowable_list.append(Spacer(1, 12))
+
+            path = graph_files.get('technique')
+            if path:
+                flowable_list.append(self.generate_graph(path, 4*inch))
+
+        return flowable_list

--- a/app/debrief-sections/technique_graph.py
+++ b/app/debrief-sections/technique_graph.py
@@ -9,17 +9,15 @@ class DebriefReportSection(BaseReportSection):
         super().__init__()
         self.id = 'technique-graph'
         self.display_name = 'Technique Graph'
-        self.section_title = 'Technique Graph'
+        self.section_title = 'TECHNIQUE GRAPH'
         self.description = 'This graph displays the order of techniques executed by the operation. A technique ' \
                            'explains the technical method or the "how" of a step.'
 
     def generate_section_elements(self, styles, **kwargs):
         flowable_list = []
-        if 'graph_files' in kwargs:
-            graph_files = kwargs.get('graph_files', {})
-            flowable_list.append(self.generate_section_title_and_description(styles))
-            path = graph_files.get('technique')
-            if path:
-                flowable_list.append(self.generate_graph(path, 4*inch))
+        path = kwargs.get('graph_files', {}).get('technique')
+        if path:
+            # Keep the title, description, and graph grouped together to avoid page break in the middle.
+            flowable_list.append(self.generate_grouped_graph_section_flowables(styles, path, 4*inch))
 
         return flowable_list

--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -78,7 +78,7 @@ class DebriefGui(BaseWorld):
         self._save_svgs(svg_data)
         if data['operations']:
             header_logo_path = None
-            if header_logo_filename:
+            if header_logo_filename and header_logo_filename != 'no-logo':
                 header_logo_path = os.path.relpath(os.path.join(self.uploads_dir, 'header-logos', header_logo_filename))
             operations = [o for o in await self.data_svc.locate('operations', match=await self._get_access(request))
                           if str(o.id) in data.get('operations')]
@@ -111,6 +111,7 @@ class DebriefGui(BaseWorld):
             filepath = os.path.relpath(os.path.join(self.uploads_dir, 'header-logos', filename))
             with open(filepath, 'wb') as f:
                 f.write(content)
+        return web.json_response(status=200)
 
     def _build_pdf(self, operations, agents, filename, sections, header_logo_path):
         # pdf setup

--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -115,12 +115,14 @@ class DebriefGui(BaseWorld):
             logo_file = logo_file_info.file
             content = logo_file.read()
             filename = logo_file_info.filename
+            self._save_uploaded_image(filename, content)
+            return web.json_response(status=200)
+        return web.json_response('No header logo file provided.')
 
-            # Write file to uploads directory
-            filepath = os.path.relpath(os.path.join(self.uploads_dir, 'header-logos', filename))
-            with open(filepath, 'wb') as f:
-                f.write(content)
-        return web.json_response(status=200)
+    def _save_uploaded_image(self, filename, content):
+        filepath = os.path.relpath(os.path.join(self.uploads_dir, 'header-logos', filename))
+        with open(filepath, 'wb') as f:
+            f.write(content)
 
     def _load_report_sections(self, plugins):
         if not self.loaded_report_sections:

--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -84,7 +84,7 @@ class DebriefGui(BaseWorld):
                           if str(o.id) in data.get('operations')]
             filename = 'debrief_' + datetime.today().strftime('%Y-%m-%d_%H-%M-%S')
             agents = await self.data_svc.locate('agents')
-            pdf_bytes = self._build_pdf(operations, agents, filename, data['ordered-sections'], header_logo_path)
+            pdf_bytes = self._build_pdf(operations, agents, filename, data['report-sections'], header_logo_path)
             self._clean_downloads()
             return web.json_response(dict(filename=filename, pdf_bytes=pdf_bytes))
         return web.json_response('No operations selected')

--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -62,7 +62,7 @@ class DebriefGui(BaseWorld):
                       if str(o.id) in data.get('operations')]
         op_displays = [o.display for o in operations]
         agents = [a.display for a in await self.data_svc.locate('agents', match=await self._get_access(request))]
-        ttps = self._generate_ttps(operations)
+        ttps = DebriefService.generate_ttps(operations)
         return web.json_response(dict(operations=op_displays, agents=agents, ttps=ttps))
 
     async def graph(self, request):

--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -84,7 +84,7 @@ class DebriefGui(BaseWorld):
                           if str(o.id) in data.get('operations')]
             filename = 'debrief_' + datetime.today().strftime('%Y-%m-%d_%H-%M-%S')
             agents = await self.data_svc.locate('agents')
-            pdf_bytes = self._build_pdf(operations, agents, filename, data['sections'], header_logo_path)
+            pdf_bytes = self._build_pdf(operations, agents, filename, data['ordered-sections'], header_logo_path)
             self._clean_downloads()
             return web.json_response(dict(filename=filename, pdf_bytes=pdf_bytes))
         return web.json_response('No operations selected')
@@ -151,38 +151,39 @@ class DebriefGui(BaseWorld):
         story_obj.append(story_obj.generate_table(agent_data, '*'))
         story_obj.page_break()
 
-        if any(v for k, v in sections.items() if '-graph' in k):
-            story_obj.append_text('OPERATIONS GRAPHS', styles['Heading2'], 0)
+        if any(v for v in sections if '-graph' in v):
             graph_files = dict()
             for file in glob.glob('./plugins/debrief/downloads/*.svg'):
                 graph_files[os.path.basename(file).split('.')[0]] = file
-            if sections['default-graph']:
-                story_obj.append_graph('graph', graph_files['graph'])
-            if sections['tactic-graph']:
-                story_obj.append_graph('tactic', graph_files['tactic'])
-            if sections['technique-graph']:
-                story_obj.append_graph('technique', graph_files['technique'])
-            if sections['fact-graph']:
-                story_obj.append_graph('fact', graph_files['fact'])
-            story_obj.page_break()
 
-        if sections['tactic-technique-table']:
-            story_obj.append_text('TACTICS AND TECHNIQUES', styles['Heading2'], 0)
-            ttps = self._generate_ttps(operations)
-            story_obj.append(story_obj.generate_ttps(ttps))
-
-        for o in operations:
-            if sections['steps-table']:
-                story_obj.append_text('STEPS IN OPERATION <font name=Courier-Bold size=17>%s</font>' % o.name.upper(),
-                                      styles['Heading2'], 0)
-                story_obj.append_text(story_obj.get_description('op steps'), styles['Normal'], 12)
-                story_obj.append(story_obj.generate_op_steps(o))
-            if sections['facts-table']:
-                story_obj.append_text('FACTS FOUND IN OPERATION <font name=Courier-Bold size=17>%s</font>' % o.name.upper(),
-                                      styles['Heading2'], 0)
-                story_obj.append_text(story_obj.get_description('op facts'), styles['Normal'], 12)
-                story_obj.append(story_obj.generate_facts_found(o))
-                story_obj.page_break()
+        for section in sections:
+            if '-graph' in section:
+                story_obj.append_text('OPERATIONS GRAPHS', styles['Heading2'], 0)
+                if section == 'default-graph':
+                    story_obj.append_graph('graph', graph_files['graph'])
+                elif section == 'tactic-graph':
+                    story_obj.append_graph('tactic', graph_files['tactic'])
+                elif section == 'technique-graph':
+                    story_obj.append_graph('technique', graph_files['technique'])
+                elif section == 'fact-graph':
+                    story_obj.append_graph('fact', graph_files['fact'])
+            elif sections == 'tactic-technique-table':
+                story_obj.append_text('TACTICS AND TECHNIQUES', styles['Heading2'], 0)
+                ttps = self._generate_ttps(operations)
+                story_obj.append(story_obj.generate_ttps(ttps))
+            elif section == 'steps-table':
+                for o in operations:
+                    story_obj.append_text('STEPS IN OPERATION <font name=Courier-Bold size=17>%s</font>' % o.name.upper(),
+                                          styles['Heading2'], 0)
+                    story_obj.append_text(story_obj.get_description('op steps'), styles['Normal'], 12)
+                    story_obj.append(story_obj.generate_op_steps(o))
+            elif section == 'facts-table':
+                for o in operations:
+                    story_obj.append_text('FACTS FOUND IN OPERATION <font name=Courier-Bold size=17>%s</font>' % o.name.upper(),
+                                          styles['Heading2'], 0)
+                    story_obj.append_text(story_obj.get_description('op facts'), styles['Normal'], 12)
+                    story_obj.append(story_obj.generate_facts_found(o))
+                    story_obj.page_break()
 
         # pdf teardown
         doc.build(story_obj.story_arr,

--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -151,17 +151,8 @@ class DebriefGui(BaseWorld):
         story_obj.set_header_logo_path(header_logo_path)
         styles = getSampleStyleSheet()
         pdfmetrics.registerFont(TTFont('VeraBd', 'VeraBd.ttf'))
-        title = styles['Heading1']
-        title.fontName = 'VeraBd'
-        title.textColor = 'maroon'
-        title.fontSize = 24
 
-        # content generation
         story_obj.append(Spacer(1, 36))
-        story_obj.append_text("OPERATIONS DEBRIEF", title, 6)
-        story_obj.append_text("<i>Generated on %s</i>" % datetime.today().strftime('%Y-%m-%d %H:%M:%S'),
-                              styles['Normal'], 12)
-        story_obj.append_text(story_obj.get_description('debrief'), styles['Normal'], 12)
 
         # Add selected module components
         graph_files = dict()
@@ -169,6 +160,7 @@ class DebriefGui(BaseWorld):
             for file in glob.glob('./plugins/debrief/downloads/*.svg'):
                 graph_files[os.path.basename(file).split('.')[0]] = file
 
+        # content generation
         try:
             for section in sections:
                 section_module = self.report_section_modules.get(section, None)

--- a/app/debrief_svc.py
+++ b/app/debrief_svc.py
@@ -138,18 +138,29 @@ class DebriefService(BaseService):
                 if not link.cleanup:
                     tactic_name = link.ability.tactic
                     if tactic_name not in ttps.keys():
-                        tactic = dict(name=tactic_name,
-                                      techniques={link.ability.technique_name: link.ability.technique_id},
-                                      steps={op.name: [link.ability.name]})
-                        ttps[tactic_name] = tactic
+                        ttps[tactic_name] = DebriefService._generate_new_tactic_entry(op, tactic_name, link)
                     else:
-                        if link.ability.technique_name not in ttps[tactic_name]['techniques'].keys():
-                            ttps[tactic_name]['techniques'][link.ability.technique_name] = link.ability.technique_id
-                        if op.name not in ttps[tactic_name]['steps'].keys():
-                            ttps[tactic_name]['steps'][op.name] = [link.ability.name]
-                        elif link.ability.name not in ttps[tactic_name]['steps'][op.name]:
-                            ttps[tactic_name]['steps'][op.name].append(link.ability.name)
+                        DebriefService._update_tactic_entry(ttps[tactic_name], op.name, link)
         return dict(sorted(ttps.items()))
+
+    @staticmethod
+    def _generate_new_tactic_entry(operation, tactic_name, link):
+        return dict(
+            name=tactic_name,
+            techniques={link.ability.technique_name: link.ability.technique_id},
+            steps={operation.name: [link.ability.name]}
+        )
+
+    @staticmethod
+    def _update_tactic_entry(tactic_entry_dict, op_name, link):
+        technique_info = tactic_entry_dict['techniques']
+        step_info = tactic_entry_dict['steps']
+        if link.ability.technique_name not in technique_info.keys():
+            technique_info[link.ability.technique_name] = link.ability.technique_id
+        if op_name not in step_info.keys():
+            step_info[op_name] = [link.ability.name]
+        elif link.ability.name not in step_info[op_name]:
+            step_info[op_name].append(link.ability.name)
 
     @staticmethod
     def _get_pub_attrs(fact):

--- a/app/debrief_svc.py
+++ b/app/debrief_svc.py
@@ -131,6 +131,27 @@ class DebriefService(BaseService):
         return graph_output
 
     @staticmethod
+    def generate_ttps(operations):
+        ttps = dict()
+        for op in operations:
+            for link in op.chain:
+                if not link.cleanup:
+                    tactic_name = link.ability.tactic
+                    if tactic_name not in ttps.keys():
+                        tactic = dict(name=tactic_name,
+                                      techniques={link.ability.technique_name: link.ability.technique_id},
+                                      steps={op.name: [link.ability.name]})
+                        ttps[tactic_name] = tactic
+                    else:
+                        if link.ability.technique_name not in ttps[tactic_name]['techniques'].keys():
+                            ttps[tactic_name]['techniques'][link.ability.technique_name] = link.ability.technique_id
+                        if op.name not in ttps[tactic_name]['steps'].keys():
+                            ttps[tactic_name]['steps'][op.name] = [link.ability.name]
+                        elif link.ability.name not in ttps[tactic_name]['steps'][op.name]:
+                            ttps[tactic_name]['steps'][op.name].append(link.ability.name)
+        return dict(sorted(ttps.items()))
+
+    @staticmethod
     def _get_pub_attrs(fact):
         return {k: v for k, v in vars(fact).items() if not k.startswith('_')}
 

--- a/app/objects/c_story.py
+++ b/app/objects/c_story.py
@@ -2,7 +2,7 @@ from lxml import etree as ET
 from reportlab.lib import colors
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.units import inch
-from reportlab.platypus import Paragraph, Spacer, Table, TableStyle, PageBreak, Image
+from reportlab.platypus import Paragraph, Spacer, Table, TableStyle, PageBreak, Image, CondPageBreak
 from svglib.svglib import svg2rlg
 
 
@@ -25,6 +25,9 @@ class Story:
 
     def page_break(self):
         self.story_arr.append(PageBreak())
+
+    def conditional_page_break(self, height):
+        self.story_arr.append(CondPageBreak(height))
 
     def generate_table(self, data, col_widths):
         data[1:] = [[self._get_table_object(val) for val in row] for row in data[1:]]
@@ -50,9 +53,9 @@ class Story:
     def append_graph(self, name, path):
         styles = getSampleStyleSheet()
         if name == 'graph':
-            self.append_text('Operations Graph', styles['Heading3'], 12)
+            self.append_text('Operations Graph', styles['Heading2'], 12)
         else:
-            self.append_text('%s Graph' % name.capitalize(), styles['Heading3'], 0)
+            self.append_text('%s Graph' % name.capitalize(), styles['Heading2'], 0)
         self.append_text(self.get_description(name), styles['Normal'], 12)
 
         self._adjust_icon_svgs(path)

--- a/app/objects/c_story.py
+++ b/app/objects/c_story.py
@@ -7,6 +7,8 @@ from svglib.svglib import svg2rlg
 
 
 class Story:
+    _header_logo_path = None
+
     def __init__(self):
         self.story_arr = []
 
@@ -87,14 +89,22 @@ class Story:
         return self.generate_table(fact_data, [1*inch, 1.2*inch, .6*inch, .6*inch, 3*inch])
 
     @staticmethod
+    def set_header_logo_path(header_logo_path):
+        Story._header_logo_path = header_logo_path
+
+    @staticmethod
     def header_footer_first(canvas, doc):
         # Save the state of our canvas so we can draw on it
         canvas.saveState()
 
         # Header
-        logo = "./plugins/debrief/static/img/caldera.png"
-        im = Image(logo, 1.5 * inch, 1 * inch)
+        caldera_logo = "./plugins/debrief/static/img/caldera.png"
+        im = Image(caldera_logo, 1.5 * inch, 1 * inch)
         im.drawOn(canvas, doc.leftMargin, doc.height + doc.topMargin - im.drawHeight / 2)
+
+        if Story._header_logo_path:
+            Story.draw_header_logo(canvas, doc, Story._header_logo_path)
+
         canvas.setStrokeColor(colors.maroon)
         canvas.setLineWidth(4)
         canvas.line(doc.leftMargin + im.drawWidth + 5,
@@ -116,6 +126,9 @@ class Story:
         canvas.saveState()
 
         # Header
+        if Story._header_logo_path:
+            Story.draw_header_logo(canvas, doc, Story._header_logo_path)
+
         canvas.setFillColor(colors.maroon)
         canvas.setFont('VeraBd', 18)
         canvas.drawString(doc.leftMargin, doc.height + doc.topMargin * 1.25, 'OPERATIONS DEBRIEF')
@@ -135,6 +148,12 @@ class Story:
 
         # Release the canvas
         canvas.restoreState()
+
+    @staticmethod
+    def draw_header_logo(canvas, doc, logo_path):
+        im = Image(logo_path, 2.5 * inch, 0.75 * inch)
+        im.drawOn(canvas, doc.width + doc.leftMargin + doc.rightMargin - im.drawWidth - 10,
+                  doc.height + doc.topMargin + doc.bottomMargin - im.drawHeight - 10)
 
     @staticmethod
     def _adjust_icon_svgs(path):

--- a/app/objects/c_story.py
+++ b/app/objects/c_story.py
@@ -1,9 +1,8 @@
 from lxml import etree as ET
 from reportlab.lib import colors
-from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.units import inch
-from reportlab.platypus import Paragraph, Spacer, Table, TableStyle, PageBreak, Image, CondPageBreak
-from svglib.svglib import svg2rlg
+from reportlab.platypus import Paragraph, Spacer, PageBreak, Image, CondPageBreak
 
 
 class Story:
@@ -28,68 +27,6 @@ class Story:
 
     def conditional_page_break(self, height):
         self.story_arr.append(CondPageBreak(height))
-
-    def generate_table(self, data, col_widths):
-        data[1:] = [[self._get_table_object(val) for val in row] for row in data[1:]]
-        tbl = Table(data, colWidths=col_widths)
-        tbl.setStyle(TableStyle([('BACKGROUND', (0, 0), (-1, 0), colors.maroon),
-                                 ('TEXTCOLOR', (0, 0), (-1, 0), colors.white),
-                                 ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-                                 ('FONTSIZE', (0, 1), (-1, -1), 8),
-                                 ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
-                                 ('VALIGN', (0, 0), (-1, -1), 'TOP'),
-                                 ('INNERGRID', (0, 0), (-1, -1), 0.5, colors.white),
-                                 ('BOX', (0, 0), (-1, -1), 0.5, colors.black),
-                                 ]))
-        for each in range(1, len(data)):
-            if each % 2 == 0:
-                bg_color = colors.lightgrey
-            else:
-                bg_color = colors.whitesmoke
-
-            tbl.setStyle(TableStyle([('BACKGROUND', (0, each), (-1, each), bg_color)]))
-        return tbl
-
-    def append_graph(self, name, path):
-        styles = getSampleStyleSheet()
-        if name == 'graph':
-            self.append_text('Operations Graph', styles['Heading2'], 12)
-        else:
-            self.append_text('%s Graph' % name.capitalize(), styles['Heading2'], 0)
-        self.append_text(self.get_description(name), styles['Normal'], 12)
-
-        self._adjust_icon_svgs(path)
-        graph = svg2rlg(path)
-        aspect = graph.height / float(graph.width)
-        self.append(Image(graph, width=4*inch, height=(4*inch * aspect)))
-
-    def generate_ttps(self, ttps):
-        ttp_data = [['Tactics', 'Techniques', 'Abilities']]
-        for key, tactic in ttps.items():
-            technique_arr = []
-            for name, tid in tactic['techniques'].items():
-                technique_arr.append(tid + ': ' + name)
-            ttp_data.append([tactic['name'].capitalize(), technique_arr, tactic['steps']])
-        return self.generate_table(ttp_data, [1.25 * inch, 3.25 * inch, 2 * inch])
-
-    def generate_op_steps(self, operation):
-        steps = [['Time', 'Status', 'Agent', 'Name', 'Command', 'Facts']]
-        for link in operation.chain:
-            steps.append(
-                [link.finish or '', self._status_name(link.status), link.paw, link.ability.name, link.decode_bytes(link.command),
-                 'Yes' if len([f for f in link.facts if f.score > 0]) > 0 else 'No'])
-
-        return self.generate_table(steps, [.75*inch, .6*inch, .6*inch, .85*inch, 3*inch, .6*inch])
-
-    def generate_facts_found(self, operation):
-        fact_data = [['Trait', 'Value', 'Score', 'Paw', 'Command Run']]
-        for lnk in operation.chain:
-            if len(lnk.facts) > 0:
-                for f in lnk.facts:
-                    fact_data.append([f.trait, f.value, str(f.score),
-                                      '<link href="#agent-{0}" color="blue">{0}</link>'.format(lnk.paw),
-                                      lnk.decode_bytes(lnk.command)])
-        return self.generate_table(fact_data, [1*inch, 1.2*inch, .6*inch, .6*inch, 3*inch])
 
     @staticmethod
     def set_header_logo_path(header_logo_path):
@@ -159,7 +96,7 @@ class Story:
                   doc.height + doc.topMargin + doc.bottomMargin - im.drawHeight - 10)
 
     @staticmethod
-    def _adjust_icon_svgs(path):
+    def adjust_icon_svgs(path):
         svg = ET.parse(path)
         for icon_svg in svg.getroot().iter("{http://www.w3.org/2000/svg}svg"):
             if icon_svg.get('id') == 'copy-svg':
@@ -172,7 +109,7 @@ class Story:
         svg.write(open(path, 'wb'))
 
     @staticmethod
-    def _get_table_object(val):
+    def get_table_object(val):
         table = ParagraphStyle(name='Table', fontSize=8)
         if type(val) == str:
             return Paragraph(val, table)
@@ -190,25 +127,6 @@ class Story:
             return Paragraph(dict_string, table)
 
     @staticmethod
-    def _status_name(status):
-        if status == 0:
-            return 'success'
-        elif status == -2:
-            return 'discarded'
-        elif status == 1:
-            return 'failure'
-        elif status == 124:
-            return 'timeout'
-        elif status == -3:
-            return 'collected'
-        elif status == -4:
-            return 'untrusted'
-        elif status == -5:
-            return 'visibility'
-        else:
-            return 'queued'
-
-    @staticmethod
     def _descriptions(obj):
         if obj == 'debrief':
             return 'This document covers the overall campaign analytics made up of the selected set of operations. ' \
@@ -216,13 +134,6 @@ class Story:
                    'graphical views of the operations, the techniques and tactics used, and the facts discovered by ' \
                    'the operations. The following sections include a more in depth review of each specific operation ' \
                    'ran.'
-        elif obj == 'statistics':
-            return 'An operation\'s planner makes up the decision making process. It contains logic for how a ' \
-                   'running operation should make decisions about which abilities to use and in what order. An ' \
-                   'objective is a collection of fact targets, called goals, which can be tied to adversaries. ' \
-                   'During the course of an operation, every time the planner is evaluated, the current objective ' \
-                   'status is evaluated in light of the current knowledge of the operation, with the operation ' \
-                   'completing should all goals be met.'
         elif obj == 'agents':
             return 'The table below displays information about the agents used. An agent\'s paw is the unique' \
                    ' identifier, or paw print, of an agent. Also included are the username of the user who executed ' \
@@ -244,9 +155,6 @@ class Story:
                    'operation where they were discovered. Facts are also attached to the facts that led to their ' \
                    'discovery. For readability, only the first 15 facts discovered in an operation are included in ' \
                    'the graph.'
-        elif obj == 'tactic':
-            return 'This graph displays the order of tactics executed by the operation. A tactic explains the ' \
-                   'general purpose or the "why" of a step.'
         elif obj == 'technique':
             return 'This graph displays the order of techniques executed by the operation. A technique explains the ' \
                    'technical method or the "how" of a step.'

--- a/app/objects/c_story.py
+++ b/app/objects/c_story.py
@@ -2,7 +2,7 @@ from lxml import etree as ET
 from reportlab.lib import colors
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.units import inch
-from reportlab.platypus import Paragraph, Spacer, PageBreak, Image, CondPageBreak
+from reportlab.platypus import Paragraph, Spacer, PageBreak, Image
 
 
 class Story:
@@ -24,9 +24,6 @@ class Story:
 
     def page_break(self):
         self.story_arr.append(PageBreak())
-
-    def conditional_page_break(self, height):
-        self.story_arr.append(CondPageBreak(height))
 
     @staticmethod
     def set_header_logo_path(header_logo_path):
@@ -125,36 +122,3 @@ class Story:
                 for list_item in v:
                     dict_string += '&nbsp;&nbsp;&nbsp;' + list_item + '<br/>'
             return Paragraph(dict_string, table)
-
-    @staticmethod
-    def _descriptions(obj):
-        if obj == 'debrief':
-            return 'This document covers the overall campaign analytics made up of the selected set of operations. ' \
-                   'The below sections contain general metadata about the selected operations as well as ' \
-                   'graphical views of the operations, the techniques and tactics used, and the facts discovered by ' \
-                   'the operations. The following sections include a more in depth review of each specific operation ' \
-                   'ran.'
-        elif obj == 'agents':
-            return 'The table below displays information about the agents used. An agent\'s paw is the unique' \
-                   ' identifier, or paw print, of an agent. Also included are the username of the user who executed ' \
-                   'the agent, the privilege level of the agent process, and the name of the agent executable.'
-        elif obj == 'op steps':
-            return 'The table below shows detailed information about the steps taken in an operation and whether the ' \
-                   'command run discovered any facts.'
-        elif obj == 'op facts':
-            return 'The table below displays the facts found in the operation, the command run and the agent that ' \
-                   'found the fact. Every fact, by default, gets a score of 1. If a host.user.password fact is ' \
-                   'important or has a high chance of success if used, you may assign it a score of 5. When an ' \
-                   'ability uses a fact to fill in a variable, it will use those with the highest scores first. A ' \
-                   'fact with a score of 0, is blacklisted - meaning it cannot be used in an operation.'
-        elif obj == 'graph':
-            return 'This is a graphical display of the agents connected to the command and control (C2), the ' \
-                   'operations run, and the steps of each operation as they relate to the agents.'
-        elif obj == 'fact':
-            return 'This graph displays the facts discovered by the operations run. Facts are attached to the ' \
-                   'operation where they were discovered. Facts are also attached to the facts that led to their ' \
-                   'discovery. For readability, only the first 15 facts discovered in an operation are included in ' \
-                   'the graph.'
-        elif obj == 'technique':
-            return 'This graph displays the order of techniques executed by the operation. A technique explains the ' \
-                   'technical method or the "how" of a step.'

--- a/app/utility/base_report_section.py
+++ b/app/utility/base_report_section.py
@@ -7,6 +7,16 @@ from plugins.debrief.app.objects.c_story import Story
 
 
 class BaseReportSection:
+    _status_names = {
+        0: 'success',
+        -2: 'discarded',
+        1: 'failure',
+        124: 'timeout',
+        -3: 'collected',
+        -4: 'untrusted',
+        -5: 'visibility',
+    }
+
     def __init__(self):
         self.id = 'base-section-template'
         self.display_name = 'Base Section Template'
@@ -14,10 +24,28 @@ class BaseReportSection:
         self.section_title = 'BASE SECTION HEADER'
 
     def generate_section_title_and_description(self, styles):
-        return KeepTogetherSplitAtTop([
+        """Return grouped flowable containing section title and description."""
+
+        flowable_list = [
             Paragraph(self.section_title, styles['Heading2']),
             Paragraph(self.description, styles['Normal']),
+        ]
+        return self.group_elements(flowable_list)
+
+    def generate_grouped_graph_section_flowables(self, styles, graph_path, graph_width):
+        """Return grouped flowable containing section title, description, and specified graph."""
+
+        return self.group_elements([
+            Paragraph(self.section_title, styles['Heading2']),
+            Paragraph(self.description, styles['Normal']),
+            self.generate_graph(graph_path, graph_width)
         ])
+
+    @staticmethod
+    def group_elements(flowable_list):
+        """Group flowables together to avoid page breaks in the middle."""
+
+        return KeepTogetherSplitAtTop(flowable_list)
 
     @staticmethod
     def generate_graph(svg_path, width):
@@ -50,19 +78,4 @@ class BaseReportSection:
 
     @staticmethod
     def status_name(status):
-        if status == 0:
-            return 'success'
-        elif status == -2:
-            return 'discarded'
-        elif status == 1:
-            return 'failure'
-        elif status == 124:
-            return 'timeout'
-        elif status == -3:
-            return 'collected'
-        elif status == -4:
-            return 'untrusted'
-        elif status == -5:
-            return 'visibility'
-        else:
-            return 'queued'
+        return BaseReportSection._status_names.get(status, 'queued')

--- a/app/utility/base_report_section.py
+++ b/app/utility/base_report_section.py
@@ -1,0 +1,68 @@
+from reportlab.lib import colors
+from reportlab.platypus import Image, Paragraph, Table, TableStyle
+from reportlab.platypus.flowables import KeepTogetherSplitAtTop
+from svglib.svglib import svg2rlg
+
+from plugins.debrief.app.objects.c_story import Story
+
+
+class BaseReportSection:
+    def __init__(self):
+        self.id = 'base-section-template'
+        self.display_name = 'Base Section Template'
+        self.description = 'Base class for debrief report section'
+        self.section_title = 'BASE SECTION HEADER'
+
+    def generate_section_title_and_description(self, styles):
+        return KeepTogetherSplitAtTop([
+            Paragraph(self.section_title, styles['Heading2']),
+            Paragraph(self.description, styles['Normal']),
+        ])
+
+    @staticmethod
+    def generate_graph(svg_path, width):
+        Story.adjust_icon_svgs(svg_path)
+        graph = svg2rlg(svg_path)
+        aspect = graph.height / float(graph.width)
+        return Image(graph, width=width, height=(width * aspect))
+
+    @staticmethod
+    def generate_table(data, col_widths):
+        data[1:] = [[Story.get_table_object(val) for val in row] for row in data[1:]]
+        tbl = Table(data, colWidths=col_widths, repeatRows=1)
+        tbl.setStyle(TableStyle([('BACKGROUND', (0, 0), (-1, 0), colors.maroon),
+                                 ('TEXTCOLOR', (0, 0), (-1, 0), colors.white),
+                                 ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+                                 ('FONTSIZE', (0, 1), (-1, -1), 8),
+                                 ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
+                                 ('VALIGN', (0, 0), (-1, -1), 'TOP'),
+                                 ('INNERGRID', (0, 0), (-1, -1), 0.5, colors.white),
+                                 ('BOX', (0, 0), (-1, -1), 0.5, colors.black),
+                                 ]))
+        for each in range(1, len(data)):
+            if each % 2 == 0:
+                bg_color = colors.lightgrey
+            else:
+                bg_color = colors.whitesmoke
+
+            tbl.setStyle(TableStyle([('BACKGROUND', (0, each), (-1, each), bg_color)]))
+        return tbl
+
+    @staticmethod
+    def status_name(status):
+        if status == 0:
+            return 'success'
+        elif status == -2:
+            return 'discarded'
+        elif status == 1:
+            return 'failure'
+        elif status == 124:
+            return 'timeout'
+        elif status == -3:
+            return 'collected'
+        elif status == -4:
+            return 'untrusted'
+        elif status == -5:
+            return 'visibility'
+        else:
+            return 'queued'

--- a/hook.py
+++ b/hook.py
@@ -1,5 +1,6 @@
 from app.utility.base_world import BaseWorld
 from plugins.debrief.app.debrief_gui import DebriefGui
+from aiohttp import web
 
 name = 'Debrief'
 description = 'some good bones'
@@ -11,6 +12,7 @@ async def enable(services):
     app = services.get('app_svc').application
     debrief_gui = DebriefGui(services)
     app.router.add_static('/debrief', 'plugins/debrief/static/', append_version=True)
+    app.router.add_static('/logodebrief', 'plugins/debrief/uploads/', append_version=True)
     app.router.add_route('GET', '/plugin/debrief/gui', debrief_gui.splash)
     app.router.add_route('POST', '/plugin/debrief/report', debrief_gui.report)
     app.router.add_route('*', '/plugin/debrief/graph', debrief_gui.graph)

--- a/hook.py
+++ b/hook.py
@@ -16,3 +16,4 @@ async def enable(services):
     app.router.add_route('*', '/plugin/debrief/graph', debrief_gui.graph)
     app.router.add_route('POST', '/plugin/debrief/pdf', debrief_gui.download_pdf)
     app.router.add_route('POST', '/plugin/debrief/json', debrief_gui.download_json)
+    app.router.add_route('POST', '/plugin/debrief/uploadlogo', debrief_gui.upload_logo)

--- a/hook.py
+++ b/hook.py
@@ -18,4 +18,4 @@ async def enable(services):
     app.router.add_route('*', '/plugin/debrief/graph', debrief_gui.graph)
     app.router.add_route('POST', '/plugin/debrief/pdf', debrief_gui.download_pdf)
     app.router.add_route('POST', '/plugin/debrief/json', debrief_gui.download_json)
-    app.router.add_route('POST', '/plugin/debrief/uploadlogo', debrief_gui.upload_logo)
+    app.router.add_route('POST', '/plugin/debrief/logo', debrief_gui.upload_logo)

--- a/static/css/debrief.css
+++ b/static/css/debrief.css
@@ -4,6 +4,14 @@
     color: var(--font-color);
 }
 
+#debrief-header-logo-list {
+    height: 150px;
+    width: 250px;
+    padding: 10px;
+    background-color: black;
+    color: var(--font-color);
+}
+
 #debrief-graph {
     background-color: black;
     height: 400px;
@@ -148,7 +156,28 @@ li.legend {
     border-color: grey;
     overflow-y: auto;
 }
+
+.debrief-logo-upload {
+	margin: 5px 5px 15px 5px;
+    text-align: center;
+}
+
 .debrief-sidebar-header {
     margin: 30px 0px;
     text-align: center;
+}
+
+.debrief-logo-upload-wrapper input[type="file"] {
+	position: absolute;
+	z-index: -1;
+	top: 6px;
+	left: 0;
+	font-size: 15px;
+	color: rgb(153, 153, 153);
+}
+
+.debrief-logo-upload-wrapper {
+	margin: 5px 5px 15px 5px;
+    text-align: center;
+    position: relative;
 }

--- a/static/css/debrief.css
+++ b/static/css/debrief.css
@@ -12,7 +12,7 @@
     color: var(--font-color);
 }
 
-#selected-pdf-section-ordering-list {
+#selected-report-section-ordering-list {
     height: 150px;
     width: 250px;
     padding: 10px;
@@ -153,7 +153,7 @@ li.legend {
     background-color: #4e4e4e;
 }
 
-.debrief-pdf-select {
+.debrief-report-select {
     width: 70%;
     height: 150px;
     padding: 10px;
@@ -190,7 +190,7 @@ li.legend {
     position: relative;
 }
 
-.debrief-pdf-section-move-button {
+.debrief-report-section-move-button {
 	align-items: center;
 	justify-content: center;
 	display: flex;
@@ -198,7 +198,7 @@ li.legend {
 	width:45%;
 }
 
-.debrief-pdf-section-move-arrow {
+.debrief-report-section-move-arrow {
 	background-color: transparent;
 	height: 12px;
 	width: 12px;

--- a/static/css/debrief.css
+++ b/static/css/debrief.css
@@ -12,6 +12,14 @@
     color: var(--font-color);
 }
 
+#selected-pdf-section-ordering-list {
+    height: 150px;
+    width: 250px;
+    padding: 10px;
+    background-color: black;
+    color: var(--font-color);
+}
+
 #debrief-graph {
     background-color: black;
     height: 400px;
@@ -180,4 +188,18 @@ li.legend {
 	margin: 5px 5px 15px 5px;
     text-align: center;
     position: relative;
+}
+
+.debrief-pdf-section-move-button {
+	align-items: center;
+	justify-content: center;
+	display: flex;
+	padding: 8px;
+	width:45%;
+}
+
+.debrief-pdf-section-move-arrow {
+	background-color: transparent;
+	height: 12px;
+	width: 12px;
 }

--- a/static/js/debrief.js
+++ b/static/js/debrief.js
@@ -373,8 +373,15 @@ function uploadHeaderLogo() {
 		fetch('/plugin/debrief/uploadlogo', {method: "POST", body: formData}).then( response => {
 			if (response.status == 200) {
 				stream("Logo file uploaded!");
-				updateLogoSelection(logoFile);
-				showLogoPreview();
+				response.json().then(data => {
+					if ('filename' in data) {
+						let returnedFilename = data['filename'];
+						updateLogoSelection(returnedFilename);
+						showLogoPreview();
+					} else {
+						stream("Did not receive uploaded filename from server.");
+					}
+				});
 			}
 		}).catch( e=> {
 			stream("Error uploading logo: " + e.message);
@@ -572,9 +579,8 @@ function moveReportSection(direction) {
 	}
 }
 
-function updateLogoSelection(logoFile) {
+function updateLogoSelection(filename) {
 	// Add the newly uploaded logo file to the displayed list of logos.
-	filename = logoFile.name;
 	let rowHTML = '<option class="header-logo-option" value="' + filename + '">' + filename + '</option>';
 	let logoList = document.getElementById("debrief-header-logo-list");
 	logoList.insertAdjacentHTML('beforeend', rowHTML);

--- a/static/js/debrief.js
+++ b/static/js/debrief.js
@@ -122,13 +122,27 @@ function switchGraphView(btn) {
 function downloadPDF() {
     stream("Generating PDF report... ");
 
+	let logoFiles = document.getElementById("logo-file").files;
+	let logoFileName = null;
     let pdfSections = {};
     $(".debrief-pdf-opt").each(function(idx, checkbox) {
         let key = $(checkbox).attr("id").split(/-(.+)/)[1];
         pdfSections[key] = $(checkbox).prop("checked");
     })
-    restRequest('POST', {'operations': $('#debrief-operation-list').val(), 'graphs': getGraphData(), 'sections': pdfSections},
-                 downloadReport("pdf"), '/plugin/debrief/pdf');
+    if (logoFiles.length > 0) {
+    	let logoFile = logoFiles[0];
+    	logoFileName = logoFile.name;
+    }
+    restRequest(
+    	'POST', {
+    		'operations': $('#debrief-operation-list').val(),
+    		'graphs': getGraphData(),
+    		'sections': pdfSections,
+    		'header-logo': $('#debrief-header-logo-list').val()
+		},
+ 		downloadReport("pdf"),
+ 		'/plugin/debrief/pdf'
+	);
 }
 
 function downloadJSON() {
@@ -360,4 +374,26 @@ function uncheckSelectAll(checkbox) {
     if (!$(checkbox).prop("checked")) {
         $("#pdf-select-all").prop("checked", false);
     }
+}
+
+function uploadHeaderLogo() {
+	let logoFiles = document.getElementById("logo-file").files;
+	if (logoFiles.length > 0){
+		let formData = new FormData();
+		formData.append("header-logo", logoFiles[0]);
+		fetch('/plugin/debrief/uploadlogo', {method: "POST", body: formData});
+	}
+}
+
+function triggerLogoUploadButton() {
+	document.getElementById('logo-file').click();
+}
+
+function displayLogoFilename() {
+	let selectedFiles = document.getElementById("logo-file").files;
+	let filename = "No logo file selected";
+	if (selectedFiles.length > 0) {
+		filename = selectedFiles[0].name;
+	}
+	document.getElementById("selected-header-logo-file").innerHTML = filename;
 }

--- a/static/js/debrief.js
+++ b/static/js/debrief.js
@@ -370,7 +370,7 @@ function uploadHeaderLogo() {
 		let formData = new FormData();
 		let logoFile = logoFiles[0];
 		formData.append("header-logo", logoFile);
-		fetch('/plugin/debrief/uploadlogo', {method: "POST", body: formData}).then( response => {
+		fetch('/plugin/debrief/logo', {method: "POST", body: formData}).then( response => {
 			if (response.status == 200) {
 				stream("Logo file uploaded!");
 				response.json().then(data => {

--- a/static/js/debrief.js
+++ b/static/js/debrief.js
@@ -109,9 +109,6 @@ $( document ).ready(function() {
             );
         })
     }
-
-	initSectionOrderingList();
-	displayReportSections();
 });
 
 function switchGraphView(btn) {
@@ -517,32 +514,44 @@ function displayReportSections() {
 	}
 }
 
-function initSectionOrderingList() {
-	var reportSectionNames = {
-		"reportsection-statistics": "Statistics",
-		"reportsection-agents": "Agents",
-		"reportsection-default-graph": "Operations Graph",
-		"reportsection-tactic-graph": "Tactic Graph",
-		"reportsection-technique-graph": "Technique Graph",
-		"reportsection-fact-graph": "Fact Graph",
-		"reportsection-tactic-technique-table": "Tactic and Technique Table",
-		"reportsection-steps-table": "Steps Tables",
-		"reportsection-facts-table": "Operation Facts Tables",
-	};
+function initSectionOrderingList(reportSectionNames) {
+	var baseReportSectionOrdering = [
+        "reportsection-statistics",
+        "reportsection-agents",
+        "reportsection-default-graph",
+        "reportsection-tactic-graph",
+        "reportsection-technique-graph",
+        "reportsection-fact-graph",
+        "reportsection-tactic-technique-table",
+        "reportsection-steps-table",
+        "reportsection-facts-table",
+    ]
 
+    var orderedReportSectionNames = {};
 	var reportSectionEnabledMapping = {};
+
+	// Make sure the base sections appear first in order
+	baseReportSectionOrdering.forEach(function(id, index) {
+		if (id in reportSectionNames) {
+			orderedReportSectionNames[id] = reportSectionNames[id]
+		}
+	});
+
 	for (var key in reportSectionNames) {
 		reportSectionEnabledMapping[key] = true;
+
+		// Fill in remaining section ordering
+		orderedReportSectionNames[key] = reportSectionNames[key]
 	}
 
 	// Contains list of element IDs for selected report sections.
-	localStorage.setItem('report-section-order', JSON.stringify(Object.keys(reportSectionNames)));
+	localStorage.setItem('report-section-order', JSON.stringify(Object.keys(orderedReportSectionNames)));
 
 	// Maps report section element IDs to whether or not they are enabled
 	localStorage.setItem('report-section-selection-dict', JSON.stringify(reportSectionEnabledMapping));
 
 	// Contains mapping of report section element IDs to their names
-	localStorage.setItem('report-section-names', JSON.stringify(reportSectionNames));
+	localStorage.setItem('report-section-names', JSON.stringify(orderedReportSectionNames));
 }
 
 function moveReportSection(direction) {

--- a/static/js/debrief.js
+++ b/static/js/debrief.js
@@ -486,8 +486,6 @@ function displayReportSections() {
 	var enabledOptGroupHTML = '<optgroup label="ENABLED SECTIONS">';
 	for (i = 0; i < orderedList.length; i++) {
 		var sectionId = orderedList[i];
-		//let rowHTML = '<option class="ordered-report-section" value="' + sectionId + '">' + displayNames[sectionId] + '</option>';
-		//document.getElementById("selected-report-section-ordering-list").insertAdjacentHTML('beforeend', rowHTML);
 		enabledOptGroupHTML += '<option class="ordered-report-section" value="' + sectionId + '">' + displayNames[sectionId] + '</option>';
 	}
 	enabledOptGroupHTML += '</optgroup>';
@@ -501,8 +499,6 @@ function displayReportSections() {
 	var numDisabled = disabledSections.length;
 	for (i = 0; i < numDisabled; i++) {
 		var sectionId = disabledSections[i];
-		//let rowHTML = '<option class="disabled-report-section" value="' + sectionId + '">[DISABLED] ' + displayNames[sectionId] + '</option>';
-		//document.getElementById("selected-report-section-ordering-list").insertAdjacentHTML('beforeend', rowHTML);
 		disabledOptGroupHTML += '<option class="disabled-report-section" value="' + sectionId + '">' + displayNames[sectionId] + '</option>';
 	}
 	disabledOptGroupHTML += '</optgroup>';
@@ -516,6 +512,7 @@ function displayReportSections() {
 
 function initSectionOrderingList(reportSectionNames) {
 	var baseReportSectionOrdering = [
+		"reportsection-main-summary",
         "reportsection-statistics",
         "reportsection-agents",
         "reportsection-default-graph",

--- a/templates/debrief.html
+++ b/templates/debrief.html
@@ -42,50 +42,29 @@
                 <h4 style="margin-bottom:0px">REPORT OPTIONS</h4>
             </div>
             <div class="sidebar-cutout debrief-sidebar" style="display: none">
-                <h5>Report Section Selection</h5>
-                <div class="debrief-report-select">
-                    <input type="checkbox" id="report-select-all" checked onClick="reportSelectAll();updateReportSectionOrderingList();">
-                    <label for="report-select-all">Select All</label>
-                    <hr style="margin: 5 0;">
-                    <input type="checkbox" class="debrief-report-opt" id="reportsection-statistics" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
-                    <label for="reportsection-statistics">Statistics</label><br>
-                    <input type="checkbox" class="debrief-report-opt" id="reportsection-agents" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
-                    <label for="reportsection-agents">Agents</label><br>
-                    <hr style="margin: 5 0;">
-                    <input type="checkbox" class="debrief-report-opt" id="reportsection-default-graph" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
-                    <label for="reportsection-default-graph">Operations Graph</label><br>
-                    <input type="checkbox" class="debrief-report-opt" id="reportsection-tactic-graph" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
-                    <label for="reportsection-tactic-graph">Tactic Graph</label><br>
-                    <input type="checkbox" class="debrief-report-opt" id="reportsection-technique-graph" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
-                    <label for="reportsection-technique-graph">Technique Graph</label><br>
-                    <input type="checkbox" class="debrief-report-opt" id="reportsection-fact-graph" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
-                    <label for="reportsection-fact-graph">Fact Graph</label><br>
-                    <input type="checkbox" class="debrief-report-opt" id="reportsection-tactic-technique-table" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
-                    <label for="reportsection-tactic-technique-table">Tactic and Technique Table</label><br>
-                    <input type="checkbox" class="debrief-report-opt" id="reportsection-steps-table" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
-                    <label for="reportsection-steps-table">Operation Steps Tables</label><br>
-                    <input type="checkbox" class="debrief-report-opt" id="reportsection-facts-table" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
-                    <label for="reportsection-facts-table">Operation Facts Tables</label><br>
-                </div>
-                <hr style="margin: 5 0 5;">
+                <h5 style="margin: 0 0 5 0">Manage Report Sections</h5>
                 <div class="debrief-section-ordering" style="margin: 5px 5px 15px 5px;">
-                    <h5 style="margin: 0 0 5 0">Reorder Report Sections</h5>
                     <select id="selected-report-section-ordering-list" size="5" style="overflow-y:auto" data-placeholder="No sections to show.">
                         <!-- Will be populated by javascript -->
                     </select>
                     <div class="section-ordering-button-container" style="width: 100%; overflow:hidden;">
-                        <button id="report-section-move-button-up" onclick="moveReportSection('up');displayReportSectionOrderingList();"
+                        <button id="report-section-move-button-up" onclick="moveReportSection('up');displayReportSections();"
                             class="button-success atomic-button debrief-report-section-move-button" type="button"
-                            style="align-items: center; justify-content: center; display: flex; padding: 8px; width:45%; float:right;">
+                            style="align-items: center; justify-content: center; display: flex; padding: 8px; width:30%; float:left;">
                             <div class="debrief-report-section-move-arrow" style="border-left: 1px solid rgba(0,0,0,1);
                                  border-top: 1px solid rgba(0,0,0,1); transform: translateY(25%) rotate(45deg);"></div>
                         </button>
-                        <button id="report-section-move-button-down" onclick="moveReportSection('down');displayReportSectionOrderingList();"
+                        <button id="report-section-move-button-down" onclick="moveReportSection('down');displayReportSections();"
                                 class="button-success atomic-button debrief-report-section-move-button" type="button"
-                                style="align-items: center; justify-content: center; display: flex; padding: 8px; width:45%; float:left;">
+                                style="align-items: center; justify-content: center; display: flex; padding: 8px; width:30%; float:left;">
                             <div class="debrief-report-section-move-arrow" style="border-right: 1px solid rgba(0,0,0,1);
                                  border-bottom: 1px solid rgba(0,0,0,1);
                                  transform: translateY(-25%) rotate(45deg);"></div>
+                        </button>
+                        <button id="report-section-toggle-button" onclick="toggleReportSection();displayReportSections();"
+                                class="button-success atomic-button" type="button"
+                                style="align-items: center; justify-content: center; display: flex; padding: 8px; width:40%; float:right;">
+                            <p style="color: black;">Enable/Disable</p>
                         </button>
                     </div>
                 </div>

--- a/templates/debrief.html
+++ b/templates/debrief.html
@@ -62,6 +62,30 @@
                     <input type="checkbox" class="debrief-pdf-opt" id="pdf-facts-table" checked onClick="uncheckSelectAll(this)">
                     <label for="pdf-facts-table">Operation Facts Tables</label><br>
                 </div>
+                <div class="debrief-header-logo-select" style="margin: 5px 5px 15px 5px;">
+                    <h5 style="margin-bottom:5px">PDF Header Logo Selection</h5>
+                    <p style="margin-bottom:5px">Select a logo to appear in the top right corner of each page.</p>
+                    <select id="debrief-header-logo-list" size="5" data-placeholder="No logos to show." style="overflow-y:auto">
+                        {% for logo in header_logos %}
+                            <option class="headerLogoOption" id="{{ logo }}" value="{{ logo }}">{{ logo }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <h5 style="margin-bottom:5px">PDF Header Logo Upload</h5>
+                <div class="debrief-logo-upload-wrapper">
+                    <button id="logo-upload-button" type="button" class="button-success atomic-button"
+                            onclick="triggerLogoUploadButton()" style="margin-bottom:0;">
+                        Select logo file
+                    </button>
+                    <p id="selected-header-logo-file">No logo file selected.</p>
+                    <input id="logo-file" name="logo" type="file" value=""
+                           onchange="displayLogoFilename();checkUploadButton()" accept="image/*"/>
+                </div>
+                <div class="debrief-logo-upload">
+                    <button id="debrief-upload-logo" type="button" class="button-notready atomic-button" style="margin-top:0;"
+                        onclick="uploadHeaderLogo()">Upload logo file</button>
+                </div>
+                <hr style="margin: 5 0 10;">
             </div>
             <div id="debrief-download" style="text-align: center;">
                 <button id="debrief-download-pdf" type="button" class="button-success atomic-button" style="margin-top:0;"
@@ -193,5 +217,9 @@
             return 'visibility';
         }
         return 'queued';
+    }
+
+    function checkUploadButton() {
+        validateFormState(($('#logo-file').val()), '#debrief-upload-logo');
     }
 </script>

--- a/templates/debrief.html
+++ b/templates/debrief.html
@@ -42,7 +42,7 @@
                 <h4 style="margin-bottom:0px">PDF REPORT OPTIONS</h4>
             </div>
             <div class="sidebar-cutout debrief-sidebar" style="display: none">
-                <h5>PDF Section Selection</h5>
+                <h5>Optional PDF Section Selection</h5>
                 <div class="debrief-pdf-select">
                     <input type="checkbox" id="pdf-select-all" checked onClick="pdfSelectAll();updatePdfSectionOrderingList();">
                     <label for="pdf-select-all">Select All</label>

--- a/templates/debrief.html
+++ b/templates/debrief.html
@@ -39,51 +39,51 @@
                 <label for="show-tactic-icons">Show steps as tactics</label>
             </div>
             <div class="sidebar-cutout sidebar-header debrief-sidebar-header">
-                <h4 style="margin-bottom:0px">PDF REPORT OPTIONS</h4>
+                <h4 style="margin-bottom:0px">REPORT OPTIONS</h4>
             </div>
             <div class="sidebar-cutout debrief-sidebar" style="display: none">
-                <h5>PDF Section Selection</h5>
-                <div class="debrief-pdf-select">
-                    <input type="checkbox" id="pdf-select-all" checked onClick="pdfSelectAll();updatePdfSectionOrderingList();">
-                    <label for="pdf-select-all">Select All</label>
+                <h5>Report Section Selection</h5>
+                <div class="debrief-report-select">
+                    <input type="checkbox" id="report-select-all" checked onClick="reportSelectAll();updateReportSectionOrderingList();">
+                    <label for="report-select-all">Select All</label>
                     <hr style="margin: 5 0;">
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-statistics" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
-                    <label for="pdf-statistics">Statistics</label><br>
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-agents" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
-                    <label for="pdf-agents">Agents</label><br>
+                    <input type="checkbox" class="debrief-report-opt" id="reportsection-statistics" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
+                    <label for="reportsection-statistics">Statistics</label><br>
+                    <input type="checkbox" class="debrief-report-opt" id="reportsection-agents" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
+                    <label for="reportsection-agents">Agents</label><br>
                     <hr style="margin: 5 0;">
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-default-graph" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
-                    <label for="pdf-default-graph">Operations Graph</label><br>
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-tactic-graph" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
-                    <label for="pdf-tactic-graph">Tactic Graph</label><br>
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-technique-graph" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
-                    <label for="pdf-technique-graph">Technique Graph</label><br>
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-fact-graph" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
-                    <label for="pdf-fact-graph">Fact Graph</label><br>
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-tactic-technique-table" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
-                    <label for="pdf-tactic-technique-table">Tactic and Technique Table</label><br>
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-steps-table" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
-                    <label for="pdf-steps-table">Operation Steps Tables</label><br>
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-facts-table" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
-                    <label for="pdf-facts-table">Operation Facts Tables</label><br>
+                    <input type="checkbox" class="debrief-report-opt" id="reportsection-default-graph" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
+                    <label for="reportsection-default-graph">Operations Graph</label><br>
+                    <input type="checkbox" class="debrief-report-opt" id="reportsection-tactic-graph" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
+                    <label for="reportsection-tactic-graph">Tactic Graph</label><br>
+                    <input type="checkbox" class="debrief-report-opt" id="reportsection-technique-graph" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
+                    <label for="reportsection-technique-graph">Technique Graph</label><br>
+                    <input type="checkbox" class="debrief-report-opt" id="reportsection-fact-graph" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
+                    <label for="reportsection-fact-graph">Fact Graph</label><br>
+                    <input type="checkbox" class="debrief-report-opt" id="reportsection-tactic-technique-table" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
+                    <label for="reportsection-tactic-technique-table">Tactic and Technique Table</label><br>
+                    <input type="checkbox" class="debrief-report-opt" id="reportsection-steps-table" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
+                    <label for="reportsection-steps-table">Operation Steps Tables</label><br>
+                    <input type="checkbox" class="debrief-report-opt" id="reportsection-facts-table" checked onClick="uncheckSelectAll(this);updateReportSectionOrderingList();">
+                    <label for="reportsection-facts-table">Operation Facts Tables</label><br>
                 </div>
                 <hr style="margin: 5 0 5;">
-                <div class="debrief-pdf-ordering" style="margin: 5px 5px 15px 5px;">
-                    <h5 style="margin: 0 0 5 0">Reorder PDF Sections</h5>
-                    <select id="selected-pdf-section-ordering-list" size="5" style="overflow-y:auto" data-placeholder="No sections to show.">
+                <div class="debrief-section-ordering" style="margin: 5px 5px 15px 5px;">
+                    <h5 style="margin: 0 0 5 0">Reorder Report Sections</h5>
+                    <select id="selected-report-section-ordering-list" size="5" style="overflow-y:auto" data-placeholder="No sections to show.">
                         <!-- Will be populated by javascript -->
                     </select>
                     <div class="section-ordering-button-container" style="width: 100%; overflow:hidden;">
-                        <button id="pdf-section-move-button-up" onclick="movePdfSection('up');displayPdfSectionOrderingList();"
-                            class="button-success atomic-button debrief-pdf-section-move-button" type="button"
+                        <button id="report-section-move-button-up" onclick="moveReportSection('up');displayReportSectionOrderingList();"
+                            class="button-success atomic-button debrief-report-section-move-button" type="button"
                             style="align-items: center; justify-content: center; display: flex; padding: 8px; width:45%; float:right;">
-                            <div class="debrief-pdf-section-move-arrow" style="border-left: 1px solid rgba(0,0,0,1);
+                            <div class="debrief-report-section-move-arrow" style="border-left: 1px solid rgba(0,0,0,1);
                                  border-top: 1px solid rgba(0,0,0,1); transform: translateY(25%) rotate(45deg);"></div>
                         </button>
-                        <button id="pdf-section-move-button-down" onclick="movePdfSection('down');displayPdfSectionOrderingList();"
-                                class="button-success atomic-button debrief-pdf-section-move-button" type="button"
+                        <button id="report-section-move-button-down" onclick="moveReportSection('down');displayReportSectionOrderingList();"
+                                class="button-success atomic-button debrief-report-section-move-button" type="button"
                                 style="align-items: center; justify-content: center; display: flex; padding: 8px; width:45%; float:left;">
-                            <div class="debrief-pdf-section-move-arrow" style="border-right: 1px solid rgba(0,0,0,1);
+                            <div class="debrief-report-section-move-arrow" style="border-right: 1px solid rgba(0,0,0,1);
                                  border-bottom: 1px solid rgba(0,0,0,1);
                                  transform: translateY(-25%) rotate(45deg);"></div>
                         </button>
@@ -91,36 +91,31 @@
                 </div>
                 <hr style="margin: 5 0 5;">
                 <div class="debrief-header-logo-select" style="margin: 5px 5px 15px 5px;">
-                    <h5 style="margin-bottom:5px">PDF Header Logo Selection</h5>
+                    <h5 style="margin-bottom:5px">Report Header Logo Selection</h5>
                     <p style="margin-bottom:5px">Select a logo to appear in the top right corner of each page.</p>
-                    <select id="debrief-header-logo-list" size="5" data-placeholder="No logos to show." style="overflow-y:auto">
+                    <select id="debrief-header-logo-list" size="5" data-placeholder="No logos to show." onchange="showLogoPreview()" style="overflow-y:auto">
+                        <option class="header-logo-option" value="no-logo" selected>Do not use a logo</option>
                         {% for logo in header_logos %}
-                            <option class="header-logo-option" id="{{ logo }}" value="{{ logo }}">{{ logo }}</option>
+                            <option class="header-logo-option" value="{{ logo }}">{{ logo }}</option>
                         {% endfor %}
                     </select>
                 </div>
-                <hr style="margin: 5 0 5;">
-                <h5 style="margin-bottom:5px">PDF Header Logo Upload</h5>
+                <div id="debrief-report-logo-preview"></div>
                 <div class="debrief-logo-upload-wrapper">
                     <button id="logo-upload-button" type="button" class="button-success atomic-button"
-                            onclick="triggerLogoUploadButton()" style="margin-bottom:0;">
-                        Select logo file
+                            onclick="triggerLogoUploadButton();" style="margin-bottom:0;">
+                        Upload logo file
                     </button>
-                    <p id="selected-header-logo-file">No logo file selected.</p>
                     <input id="logo-file" name="logo" type="file" value=""
-                           onchange="displayLogoFilename();checkUploadButton()" accept="image/*"/>
-                </div>
-                <div class="debrief-logo-upload">
-                    <button id="debrief-upload-logo" type="button" class="button-notready atomic-button" style="margin-top:0;"
-                        onclick="uploadHeaderLogo()">Upload logo file</button>
+                           onchange="uploadHeaderLogo();" accept="image/*"/>
                 </div>
                 <hr style="margin: 5 0 10;">
             </div>
             <div id="debrief-download" style="text-align: center;">
                 <button id="debrief-download-pdf" type="button" class="button-success atomic-button" style="margin-top:0;"
-                        onclick="downloadPDF()">Download PDF</button>
+                        onclick="downloadPDF()">Download Report PDF</button>
                 <button id="debrief-download-raw" type="button" class="button-success atomic-button"
-                        style="margin-top:0;" onclick="downloadJSON()">Download JSON</button>
+                        style="margin-top:0;" onclick="downloadJSON()">Download Operation JSON</button>
             </div>
         </div>
 

--- a/templates/debrief.html
+++ b/templates/debrief.html
@@ -44,33 +44,57 @@
             <div class="sidebar-cutout debrief-sidebar" style="display: none">
                 <h5>PDF Section Selection</h5>
                 <div class="debrief-pdf-select">
-                    <input type="checkbox" id="pdf-select-all" checked onClick="pdfSelectAll()">
+                    <input type="checkbox" id="pdf-select-all" checked onClick="pdfSelectAll();updatePdfSectionOrderingList();">
                     <label for="pdf-select-all">Select All</label>
                     <hr style="margin: 5 0;">
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-default-graph" checked onClick="uncheckSelectAll(this)">
+                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-default-graph" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
                     <label for="pdf-default-graph">Operations Graph</label><br>
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-tactic-graph" checked onClick="uncheckSelectAll(this)">
+                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-tactic-graph" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
                     <label for="pdf-tactic-graph">Tactic Graph</label><br>
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-technique-graph" checked onClick="uncheckSelectAll(this)">
+                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-technique-graph" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
                     <label for="pdf-technique-graph">Technique Graph</label><br>
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-fact-graph" checked onClick="uncheckSelectAll(this)">
+                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-fact-graph" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
                     <label for="pdf-fact-graph">Fact Graph</label><br>
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-tactic-technique-table" checked onClick="uncheckSelectAll(this)">
+                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-tactic-technique-table" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
                     <label for="pdf-tactic-technique-table">Tactic and Technique Table</label><br>
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-steps-table" checked onClick="uncheckSelectAll(this)">
+                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-steps-table" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
                     <label for="pdf-steps-table">Operation Steps Tables</label><br>
-                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-facts-table" checked onClick="uncheckSelectAll(this)">
+                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-facts-table" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
                     <label for="pdf-facts-table">Operation Facts Tables</label><br>
                 </div>
+                <hr style="margin: 5 0 5;">
+                <div class="debrief-pdf-ordering" style="margin: 5px 5px 15px 5px;">
+                    <h5 style="margin: 0 0 5 0">Reorder PDF Sections</h5>
+                    <select id="selected-pdf-section-ordering-list" size="5" style="overflow-y:auto" data-placeholder="No sections to show.">
+                        <!-- Will be populated by javascript -->
+                    </select>
+                    <div class="section-ordering-button-container" style="width: 100%; overflow:hidden;">
+                        <button id="pdf-section-move-button-up" onclick="movePdfSection('up');displayPdfSectionOrderingList();"
+                            class="button-success atomic-button debrief-pdf-section-move-button" type="button"
+                            style="align-items: center; justify-content: center; display: flex; padding: 8px; width:45%; float:right;">
+                            <div class="debrief-pdf-section-move-arrow" style="border-left: 1px solid rgba(0,0,0,1);
+                                 border-top: 1px solid rgba(0,0,0,1); transform: translateY(25%) rotate(45deg);"></div>
+                        </button>
+                        <button id="pdf-section-move-button-down" onclick="movePdfSection('down');displayPdfSectionOrderingList();"
+                                class="button-success atomic-button debrief-pdf-section-move-button" type="button"
+                                style="align-items: center; justify-content: center; display: flex; padding: 8px; width:45%; float:left;">
+                            <div class="debrief-pdf-section-move-arrow" style="border-right: 1px solid rgba(0,0,0,1);
+                                 border-bottom: 1px solid rgba(0,0,0,1);
+                                 transform: translateY(-25%) rotate(45deg);"></div>
+                        </button>
+                    </div>
+                </div>
+                <hr style="margin: 5 0 5;">
                 <div class="debrief-header-logo-select" style="margin: 5px 5px 15px 5px;">
                     <h5 style="margin-bottom:5px">PDF Header Logo Selection</h5>
                     <p style="margin-bottom:5px">Select a logo to appear in the top right corner of each page.</p>
                     <select id="debrief-header-logo-list" size="5" data-placeholder="No logos to show." style="overflow-y:auto">
                         {% for logo in header_logos %}
-                            <option class="headerLogoOption" id="{{ logo }}" value="{{ logo }}">{{ logo }}</option>
+                            <option class="header-logo-option" id="{{ logo }}" value="{{ logo }}">{{ logo }}</option>
                         {% endfor %}
                     </select>
                 </div>
+                <hr style="margin: 5 0 5;">
                 <h5 style="margin-bottom:5px">PDF Header Logo Upload</h5>
                 <div class="debrief-logo-upload-wrapper">
                     <button id="logo-upload-button" type="button" class="button-success atomic-button"

--- a/templates/debrief.html
+++ b/templates/debrief.html
@@ -64,7 +64,11 @@
                         <button id="report-section-toggle-button" onclick="toggleReportSection();displayReportSections();"
                                 class="button-success atomic-button" type="button"
                                 style="align-items: center; justify-content: center; display: flex; padding: 8px; width:40%; float:right;">
-                            <p style="color: black;">Enable/Disable</p>
+                            <p style="color: black;">Enable/Disable
+
+
+
+                            </p>
                         </button>
                     </div>
                 </div>
@@ -225,4 +229,7 @@
     function checkUploadButton() {
         validateFormState(($('#logo-file').val()), '#debrief-upload-logo');
     }
+
+    initSectionOrderingList({{ report_sections|safe }});
+	displayReportSections();
 </script>

--- a/templates/debrief.html
+++ b/templates/debrief.html
@@ -42,10 +42,15 @@
                 <h4 style="margin-bottom:0px">PDF REPORT OPTIONS</h4>
             </div>
             <div class="sidebar-cutout debrief-sidebar" style="display: none">
-                <h5>Optional PDF Section Selection</h5>
+                <h5>PDF Section Selection</h5>
                 <div class="debrief-pdf-select">
                     <input type="checkbox" id="pdf-select-all" checked onClick="pdfSelectAll();updatePdfSectionOrderingList();">
                     <label for="pdf-select-all">Select All</label>
+                    <hr style="margin: 5 0;">
+                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-statistics" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
+                    <label for="pdf-statistics">Statistics</label><br>
+                    <input type="checkbox" class="debrief-pdf-opt" id="pdf-agents" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
+                    <label for="pdf-agents">Agents</label><br>
                     <hr style="margin: 5 0;">
                     <input type="checkbox" class="debrief-pdf-opt" id="pdf-default-graph" checked onClick="uncheckSelectAll(this);updatePdfSectionOrderingList();">
                     <label for="pdf-default-graph">Operations Graph</label><br>


### PR DESCRIPTION
Multiple changes:
- Users can now upload image files to use as headers on the top-right of each page in the report
- Users can reorder report sections and disable unwanted ones
- Report sections have been converted into modules. Users can create custom modules in plugins by adding appropriate python classes in the `app/debrief-sections` directory of a plugin
- Wording changed from "PDF" to "report" where applicable