### PR TITLE
VIRTS1781: Debrief PDFs not displaying Acrobat Reader

### DIFF
--- a/app/debrief-sections/main_summary.py
+++ b/app/debrief-sections/main_summary.py
@@ -19,7 +19,7 @@ class DebriefReportSection(BaseReportSection):
 
     def generate_section_elements(self, styles, **kwargs):
         title = styles['Heading1']
-        title.fontName = 'VeraBd'
+        title.fontName = 'Helvetica-Bold'
         title.textColor = 'maroon'
         title.fontSize = 24
         timestamp = "<i>Generated on %s</i>" % datetime.today().strftime('%Y-%m-%d %H:%M:%S')

--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -156,7 +156,6 @@ class DebriefGui(BaseWorld):
         story_obj = Story()
         story_obj.set_header_logo_path(header_logo_path)
         styles = getSampleStyleSheet()
-        pdfmetrics.registerFont(TTFont('VeraBd', 'VeraBd.ttf'))
 
         story_obj.append(Spacer(1, 36))
 

--- a/app/objects/c_story.py
+++ b/app/objects/c_story.py
@@ -67,7 +67,7 @@ class Story:
             Story.draw_header_logo(canvas, doc, Story._header_logo_path)
 
         canvas.setFillColor(colors.maroon)
-        canvas.setFont('VeraBd', 18)
+        canvas.setFont('Helvetica-Bold', 18)
         canvas.drawString(doc.leftMargin, doc.height + doc.topMargin * 1.25, 'OPERATIONS DEBRIEF')
         canvas.setStrokeColor(colors.maroon)
         canvas.setLineWidth(4)


### PR DESCRIPTION
Appears to have been a bug associated with selecting the font `VeraBd` (Vera bold), the issue disappeared once the title and header fonts were changed to `Helvetica-Bold` instead of `VeraBd`. 

Vera is a font unique to ReportLab, I had initially used it because it was in the ReportLab examples and I thought it looked nice, no further justification aside from that. 

I'm thinking the issue may have been somewhere along the lines of how the ReportLab-specific font is saved in the generated PDF file. There is, however, no indication in the ReportLab documentation that using the Vera font causes issues when opening the generated PDF in Adobe Acrobat Reader. Opting to use a more popular/generic font seems to be the easiest decision at this point to ensure proper load into any PDF reader.

Example PDF with Helvetica instead: [debrief_2021-01-25_16-46-22.pdf](https://github.com/mitre/debrief/files/5869868/debrief_2021-01-25_16-46-22.pdf)
