### PR TITLE
bug fix for fact graph to remove polylines connected to the removed node

### DIFF
--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -416,8 +416,13 @@ function limitFactsDisplayed(operations) {
         $("#fact-limit-msg p").html("More than " + factDisplayLimit + " facts found in the operation(s) selected. For readability, only the first " + factDisplayLimit + " facts of each operation are displayed.");
         $("#fact-limit-msg").show();
         operations.forEach(function(opId) {
-            $("#debrief-fact-svg g.fact[data-op='" + opId + "']").slice(factDisplayLimit).remove();
-            $("#debrief-fact-svg polyline.relationship[data-source='" + opId + "']").slice(factDisplayLimit).remove();
+            let nodesToRemove = $("#debrief-fact-svg g.fact[data-op='" + opId + "']").splice(factDisplayLimit);
+            nodesToRemove.forEach(function(node) {
+                let nodeId = node.id.split("node-")[1];
+                $("#debrief-fact-svg polyline.relationship[data-source='" + nodeId + "']").remove();
+                $("#debrief-fact-svg polyline.relationship[data-target='" + nodeId + "']").remove();
+                node.remove();
+            })
         })
     }
 }


### PR DESCRIPTION
## Description

When limiting facts, not all polylines to the removed node were properly removed. This bug fix properly looks for any polylines connected to the node and removes them.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Displayed two duplicate operations creating the same fact relationships and limited the facts to cut off some nodes

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
