### PR TITLE
d3 link missing between operation and fact nodes sometimes

### DIFF
--- a/app/debrief_svc.py
+++ b/app/debrief_svc.py
@@ -110,7 +110,7 @@ class DebriefService(BaseService):
                                    type='relationship')
                     op_links.append(d3_link)
 
-            self._link_relationshipless_facts(op_nodes, op_links, op_id)
+            self._link_nontargeted_facts(op_nodes, op_links, op_id)
 
             graph_output['nodes'].extend([n for n in op_nodes if n not in graph_output['nodes']])
             graph_output['links'].extend([lnk for lnk in op_links if lnk not in graph_output['links']])
@@ -216,7 +216,7 @@ class DebriefService(BaseService):
         return timestamp.replace(" ", "T")
 
     @staticmethod
-    def _link_relationshipless_facts(op_nodes, op_links, op_id):
+    def _link_nontargeted_facts(op_nodes, op_links, op_id):
         for n in op_nodes:
             target_links = [lnk for lnk in op_links if lnk['target'] == n['id']]
             if not target_links:


### PR DESCRIPTION
## Description
When displaying two operations that found the same facts, a d3 link would be missing between one of the operations and the fact because the previous logic assumed that as long as there was an existing link where the fact was the target, there was no need to add an additional link.

![MicrosoftTeams-image](https://user-images.githubusercontent.com/61020544/109344775-3310a880-783d-11eb-997f-a51b07eb950f.png)

The proposed changes:
- all d3 links and nodes relevant to the current operation saved in `op_links` and `op_nodes`, respectively
- create nodes for unique facts only (if two facts objects have the same trait and value, they are not unique)
- prioritize creating d3 links for fact nodes that are source facts, then create d3 links between facts in relationships, and then, lastly, create d3 links for facts that are not already targeted
- add only the unique d3 links and nodes to the final `graph_output`

![image](https://user-images.githubusercontent.com/61020544/109343908-04460280-783c-11eb-96cc-a3ddcba9435d.png)

Note: the example in the screencap above is an interesting case for displaying relationships because of the Relationship created in the Find Files ability:
```
source: host.file.path
edge: has_extension
target: file.sensitive.extension
```
which sets the `source` as the fact found by the ability and the `target` as the fact used by the ability. This results in the additional d3 links in the graph linking the `host.file.path` nodes to the operation node (because prior to the last step of creating d3 links, nothing was pointing to the node).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Displayed two operations that found the same facts
- Displayed two operations where the facts found were not part of a Relationship
- Dispalyed two operations where the facts found were part of a Relationship

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
