### PR TITLE
typo in debrief log name, sliced fact values overflowing the page

### DIFF
--- a/app/debrief-sections/facts_table.py
+++ b/app/debrief-sections/facts_table.py
@@ -4,6 +4,8 @@ from reportlab.platypus.flowables import KeepTogetherSplitAtTop
 
 from plugins.debrief.app.utility.base_report_section import BaseReportSection
 
+table_char_limit = 1800
+
 
 class DebriefReportSection(BaseReportSection):
     def __init__(self):
@@ -34,10 +36,14 @@ class DebriefReportSection(BaseReportSection):
 
     def _generate_facts_table(self, operation):
         fact_data = [['Trait', 'Value', 'Score', 'Paw', 'Command Run']]
+        exceeds_cell_msg = '... <font color="maroon"><i>(Value exceeds table cell character limit)</i></font>'
         for lnk in operation.chain:
             if len(lnk.facts) > 0:
                 for f in lnk.facts:
-                    fact_data.append([f.trait, f.value, str(f.score),
-                                      '<link href="#agent-{0}" color="blue">{0}</link>'.format(lnk.paw),
-                                      lnk.decode_bytes(lnk.command)])
-        return self.generate_table(fact_data, [1 * inch, 1.2 * inch, .6 * inch, .6 * inch, 3 * inch])
+                    fact_data.append(
+                        [f.trait,
+                         f.value if len(f.value) < table_char_limit else f.value[:table_char_limit] + exceeds_cell_msg,
+                         str(f.score),
+                         '<link href="#agent-{0}" color="blue">{0}</link>'.format(lnk.paw),
+                         lnk.decode_bytes(lnk.command)])
+        return self.generate_table(fact_data, [1 * inch, 2.1 * inch, .6 * inch, .6 * inch, 2.1 * inch])

--- a/app/debrief-sections/facts_table.py
+++ b/app/debrief-sections/facts_table.py
@@ -4,7 +4,7 @@ from reportlab.platypus.flowables import KeepTogetherSplitAtTop
 
 from plugins.debrief.app.utility.base_report_section import BaseReportSection
 
-table_char_limit = 1800
+TABLE_CHAR_LIMIT = 1800
 
 
 class DebriefReportSection(BaseReportSection):
@@ -42,7 +42,7 @@ class DebriefReportSection(BaseReportSection):
                 for f in lnk.facts:
                     fact_data.append(
                         [f.trait,
-                         f.value if len(f.value) < table_char_limit else f.value[:table_char_limit] + exceeds_cell_msg,
+                         f.value if len(f.value) < TABLE_CHAR_LIMIT else f.value[:TABLE_CHAR_LIMIT] + exceeds_cell_msg,
                          str(f.score),
                          '<link href="#agent-{0}" color="blue">{0}</link>'.format(lnk.paw),
                          lnk.decode_bytes(lnk.command)])

--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -186,7 +186,7 @@ class DebriefGui(BaseWorld):
                       onFirstPage=story_obj.header_footer_first,
                       onLaterPages=story_obj.header_footer_rest)
         except Exception as e:
-            self.logger.error(e)
+            self.log.error(e)
         pdf_value = pdf_buffer.getvalue()
         pdf_buffer.close()
         return pdf_value.decode('utf-8', errors='ignore')


### PR DESCRIPTION
## Description

Typo corrected in the call to the debrief logger (`log` vs. `logger`). Sliced Fact values that are longer than 1800 characters. Extremely long values caused issues in generating the PDF fact table if they overflowed into multiple pages. 

Possibly related issue: https://github.com/mitre/caldera/issues/2066

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
 
## How Has This Been Tested?

- Running the Find User Processes ability on my machine tends to result in very long fact values that are parsed by the learning_svc. Ensured PDF generation was still successful and extremely long fact values were sliced properly

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
