### PR TITLE
Reportlab trustedHosts

### DIFF
--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -9,6 +9,7 @@ from aiohttp_jinja2 import template
 from datetime import datetime
 from importlib import import_module
 from io import BytesIO
+from reportlab import rl_settings
 from reportlab.lib.pagesizes import letter
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.pdfbase import pdfmetrics
@@ -19,7 +20,6 @@ from app.service.auth_svc import for_all_public_methods, check_authorization
 from app.utility.base_world import BaseWorld
 from plugins.debrief.app.debrief_svc import DebriefService
 from plugins.debrief.app.objects.c_story import Story
-
 
 @for_all_public_methods(check_authorization)
 class DebriefGui(BaseWorld):
@@ -37,6 +37,8 @@ class DebriefGui(BaseWorld):
         self.report_section_modules = dict()
         self.report_section_names = dict()
         self.loaded_report_sections = False
+
+        rl_settings.trustedHosts = [BaseWorld.get_config('host')]
 
     async def _get_access(self, request):
         return dict(access=tuple(await self.auth_svc.get_permissions(request)))

--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -21,6 +21,7 @@ from app.utility.base_world import BaseWorld
 from plugins.debrief.app.debrief_svc import DebriefService
 from plugins.debrief.app.objects.c_story import Story
 
+
 @for_all_public_methods(check_authorization)
 class DebriefGui(BaseWorld):
     def __init__(self, services):
@@ -38,7 +39,7 @@ class DebriefGui(BaseWorld):
         self.report_section_names = dict()
         self.loaded_report_sections = False
 
-        rl_settings.trustedHosts = [BaseWorld.get_config('host')]
+        rl_settings.trustedHosts = BaseWorld.get_config(prop='reportlab_trusted_hosts', name='debrief') or None
 
     async def _get_access(self, request):
         return dict(access=tuple(await self.auth_svc.get_permissions(request)))

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -1,3 +1,6 @@
 ---
 
+# List of hosts trusted for remote content. Supports glob wildcards.
+# Leaving this empty means no hosts restrictions are applied
+# see: https://www.reportlab.com/docs/reportlab-userguide.pdf
 reportlab_trusted_hosts: []

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -1,0 +1,3 @@
+---
+
+reportlab_trusted_hosts: []

--- a/hook.py
+++ b/hook.py
@@ -9,6 +9,7 @@ access = BaseWorld.Access.RED
 
 
 async def enable(services):
+    BaseWorld.apply_config('debrief', BaseWorld.strip_yml('plugins/debrief/conf/default.yml')[0])
     app = services.get('app_svc').application
     debrief_gui = DebriefGui(services)
     app.router.add_static('/debrief', 'plugins/debrief/static/', append_version=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 lxml>=4.6.2
-reportlab==3.5.49
+reportlab==3.5.64
 svglib==1.0.1


### PR DESCRIPTION
## Description

Addressing issue in https://snyk.io/vuln/SNYK-PYTHON-REPORTLAB-1022145

Currently, debrief does not load any resources from URLs, but adding the trustedHosts if some support for this is added in the future.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Generated report from an operation pre-change. Compared with report post-change. No differences.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
