### PR TITLE
VIRTS-1952: Changing Link IDs to UUID

### DIFF
--- a/static/js/debrief.js
+++ b/static/js/debrief.js
@@ -59,7 +59,9 @@ $( document ).ready(function() {
                     .append($("<button></button>")
                         .text("Show Command")
                         .attr("data-encoded-cmd", step.command)
-                        .attr("onclick", "findResults(this, " + step.id + ")")
+                        .click(event => {
+                            findResults($(event.currentTarget), step.id)
+                        })
                     )
                 )
             );


### PR DESCRIPTION
## Description

Change Link IDs to use UUIDs instead of integers.

See: https://github.com/mitre/caldera/pull/2092

An integer would not require quotes in the attribute, but a string would. Fix is to use jQuery's `click()` function, rather than putting quotes in the attribute.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Run an operation, view link output in debrief.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
