### PR TITLE
Update reportlab version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 lxml>=4.6.2
-reportlab==3.5.64
+reportlab==3.5.67
 svglib==1.0.1


### PR DESCRIPTION
## Description

Previously pinned version was yanked: https://pypi.org/project/reportlab/#history

The old version is still installable but pip would give a warning.

## Type of change

- [X] Dependency version update

## How Has This Been Tested?

Ran Thief in an operation, viewed it in debrief, downloaded the pdf and viewed it.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
