### PR TITLE
Decoding unicode correctly

### DIFF
--- a/static/js/debrief.js
+++ b/static/js/debrief.js
@@ -181,7 +181,7 @@ function downloadReport(downloadType) {
 function findResults(elem, lnk){
     function loadResults(data){
         if (data) {
-            let res = atob(data.output);
+            let res = b64DecodeUnicode(data.output);
             $('#debrief-step-modal-view').text(res);
             let resultText = $('#debrief-step-modal-view').html();
             $.each(data.link.facts, function (k, v) {
@@ -192,7 +192,7 @@ function findResults(elem, lnk){
         }
     }
     document.getElementById('debrief-step-modal').style.display='block';
-    $('#debrief-step-modal-cmd').text(atob($(elem).attr('data-encoded-cmd')));
+    $('#debrief-step-modal-cmd').text(b64DecodeUnicode($(elem).attr('data-encoded-cmd')));
     restRequest('POST', {'index':'result','link_id':lnk}, loadResults);
 }
 


### PR DESCRIPTION
## Description

The front end did not display unicode correctly in many locations. This change uses new Javascript functions to correctly encode and decode unicode to and from base64. 

This PR is dependent on https://github.com/mitre/caldera/pull/2130.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested manually to verify that the bug was fixed and that nothing else was broken.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
