### PR TITLE
VIRTS-1805 Use CSS.escape() in selecting icon for nodes

### DIFF
--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -385,10 +385,10 @@ function cloneImgIcon(d) {
     let c;
     try {
         if (d.img.indexOf(" ") == -1 && $("#" + d.img + "-img").length > 0) {
-            c = $("#" + d.img + "-img")[0].cloneNode(true);
+            c = $("#" + CSS.escape(d.img) + "-img")[0].cloneNode(true);
         }
         else {
-            c = $("#" + d.type + "-img")[0].cloneNode(true);
+            c = $("#" + CSS.escape(d.type) + "-img")[0].cloneNode(true);
         }
     }
     catch {


### PR DESCRIPTION
## Description

Use CSS.escape() in icon selection for nodes. 

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested code with current release to make sure it behaved properly.
Tested code by introducing known bug with '(auto-generated)' string. 


## Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have made corresponding changes to the documentation
- [  ] I have added tests that prove my fix is effective or that my feature works
