### PR TITLE
Fix fact.created formatting

### DIFF
--- a/app/debrief_svc.py
+++ b/app/debrief_svc.py
@@ -93,7 +93,7 @@ class DebriefService(BaseService):
                     id_store['fact' + fact.unique] = node_id = max(id_store.values()) + 1
                     node = dict(name=fact.trait, id=node_id, type='fact', operation=op_id,
                                 attrs=self._get_pub_attrs(fact), img='fact',
-                                timestamp=self._format_timestamp(fact.created))
+                                timestamp=fact.created.strftime('%Y-%m-%dT%H:%M:%S'))
                 else:
                     node_id = id_store['fact' + fact.unique]
                     node = next(n for n in graph_output['nodes'] if n['id'] == node_id)


### PR DESCRIPTION
## Description

After the Fact update in https://github.com/mitre/caldera/pull/2152, `Fact.created` is a `DateTime` object rather than a string - similar to `Agent.created` - which caused a TypeError. This PR fixes it.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran an operation, tried to open it in debrief. Got an error. Made this change, tried to open the operation in debrief again and this time it worked without error.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
