### PR TITLE
XXE Injection Fix

### DIFF
--- a/app/objects/c_story.py
+++ b/app/objects/c_story.py
@@ -94,7 +94,8 @@ class Story:
 
     @staticmethod
     def adjust_icon_svgs(path):
-        svg = ET.parse(path)
+        parser = ET.XMLParser(resolve_entities=False)
+        svg = ET.parse(path, parser)
         for icon_svg in svg.getroot().iter("{http://www.w3.org/2000/svg}svg"):
             if icon_svg.get('id') == 'copy-svg':
                 continue


### PR DESCRIPTION
## Description

XML External Entity Injection (XXE) may allow an attacker to interfere with the Debrief' plugins processing of XML data. A proof of concept demonstrated various XXE attack vectors to view files on the server's filesystem. This PR disables resolving external entities with the plugins ET parser to remediate.

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested by running an operation in CALDERA and downloading the PDF report using debrief (with and without XXE injection attacks against various fields). The resulting PDF was visually inspected.


## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
