### PR TITLE
Report generation time now shown in UTC

### DIFF
--- a/app/debrief-sections/main_summary.py
+++ b/app/debrief-sections/main_summary.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from reportlab.platypus import Paragraph, Spacer
 from reportlab.platypus.flowables import KeepTogetherSplitAtTop
 
@@ -22,7 +22,7 @@ class DebriefReportSection(BaseReportSection):
         title.fontName = 'Helvetica-Bold'
         title.textColor = 'maroon'
         title.fontSize = 24
-        timestamp = "<i>Generated on %s</i>" % datetime.today().strftime('%Y-%m-%d %H:%M:%S')
+        timestamp = "<i>Generated on %s</i>" % datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
         return [
             KeepTogetherSplitAtTop([
                 Paragraph(self.section_title, title),


### PR DESCRIPTION
## Description
Update debrief plugin so that the generated timestamp in the PDF is in UTC format (e.g `Generated on 2021-12-22T13:20:42Z`)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Downloaded a PDF report and verified that the timestamps in the report were in UTC format.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
