### PR TITLE
VIRTS-3499 Update to use list of strings (Link IDs) instead of list of Links

### DIFF
--- a/app/debrief-sections/facts_table.py
+++ b/app/debrief-sections/facts_table.py
@@ -39,11 +39,14 @@ class DebriefReportSection(BaseReportSection):
         exceeds_cell_msg = '... <font color="maroon"><i>(Value exceeds table cell character limit)</i></font>'
         facts = await operation.all_facts()
         for f in facts:
-            try:
-                lnk = f.links[0]
-                paw_value = '<link href="#agent-{0}" color="blue">{0}</link>'.format(lnk.paw)
-                command_value = lnk.decode_bytes(lnk.command)
-            except IndexError:
+            if f.collected_by:
+                paw_links = []
+                for paw in f.collected_by:
+                    paw_links.append('<link href="#agent-{0}" color="blue">{0}</link>'.format(paw))
+                paw_value = ', '.join(paw_links)
+                commands = set([lnk.decode_bytes(lnk.command) for lnk in operation.chain if lnk.id in f.links])
+                command_value = '<br />'.join(commands)
+            else:
                 paw_value = f'{f.source[:3] + ".." + f.source[-3:]}'
                 command_value = f'No Command ({f.origin_type.name})'
             fact_data.append(

--- a/app/debrief_svc.py
+++ b/app/debrief_svc.py
@@ -199,7 +199,7 @@ class DebriefService(BaseService):
         filtered_fact['origin_type'] = filtered_fact['origin_type'].name
         temp = []
         for lnk in filtered_fact['links']:
-            temp.append(lnk.id)
+            temp.append(lnk)
         filtered_fact['links'] = temp
         return filtered_fact
 


### PR DESCRIPTION
## Description

This PR resolves a bug that caused the fact graph to not render when selecting an operation in the Debrief GUI and the PDF download to fail (an empty PDF is generated) when the Fact Table section is included in the PDF. The cause of the bug was a list of Links being used instead of a list of strings (Link IDs) when using `Fact.links`.

The proposed change will also account for Facts that have been discovered by multiple agents (more than one paw listed in `collected_by`) and also, therefore, multiple commands ran to discover the same Fact. If the commands ran that discovered the same Fact are also the same, the command is only shown once in the Fact Table.

Investigating this bug also led to the discovery of a different (unrelated) bug in core: https://github.com/mitre/caldera/pull/2432

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran an operation against two agents that discovered the same facts and ensure the graphs were generated as expected in the debrief GUI and the Fact table in the PDF downloaded is rendered properly.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
