### PR TITLE
VIRTS-2229 Renamed default graph and reordered graph display

### DIFF
--- a/app/debrief-sections/steps_graph.py
+++ b/app/debrief-sections/steps_graph.py
@@ -6,15 +6,15 @@ from plugins.debrief.app.utility.base_report_section import BaseReportSection
 class DebriefReportSection(BaseReportSection):
     def __init__(self):
         super().__init__()
-        self.id = 'default-graph'
-        self.display_name = 'Operations Graph'
-        self.section_title = 'OPERATIONS GRAPH'
+        self.id = 'steps-graph'
+        self.display_name = 'Steps Graph'
+        self.section_title = 'STEPS GRAPH'
         self.description = 'This is a graphical display of the agents connected to the command and control (C2), the ' \
                            'operations run, and the steps of each operation as they relate to the agents.'
 
     async def generate_section_elements(self, styles, **kwargs):
         flowable_list = []
-        path = kwargs.get('graph_files', {}).get('graph')
+        path = kwargs.get('graph_files', {}).get('steps')
         if path:
             # Keep the title, description, and graph grouped together to avoid page break in the middle.
             flowable_list.append(self.generate_grouped_graph_section_flowables(styles, path, 4*inch))

--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -68,7 +68,7 @@ class DebriefGui(BaseWorld):
 
     async def graph(self, request):
         graphs = {
-            'graph': self.debrief_svc.build_operation_d3,
+            'steps': self.debrief_svc.build_steps_d3,
             'attackpath': self.debrief_svc.build_attackpath_d3,
             'fact': self.debrief_svc.build_fact_d3,
             'tactic': self.debrief_svc.build_tactic_d3,

--- a/app/debrief_svc.py
+++ b/app/debrief_svc.py
@@ -11,7 +11,7 @@ class DebriefService(BaseService):
         self.data_svc = services.get('data_svc')
         self.log = logging.getLogger('debrief_svc')
 
-    async def build_operation_d3(self, operation_ids):
+    async def build_steps_d3(self, operation_ids):
         graph_output = dict(nodes=[], links=[])
         id_store = dict(c2=0)
         graph_output['nodes'].append(dict(name="C2 Server", type='c2', label='server', id=0, img='server',

--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -106,7 +106,7 @@ function updateReportGraph(operations) {
     d3.selectAll('.debrief-svg > *').remove();
 
     graphs = [
-        { id: '#debrief-graph-svg', type: 'graph', tooltip: d3.select('#op-tooltip'), simulation: createForceSimulation('operation'), svg: d3.select('#debrief-graph-svg') },
+        { id: '#debrief-steps-svg', type: 'steps', tooltip: d3.select('#op-tooltip'), simulation: createForceSimulation('operation'), svg: d3.select('#debrief-steps-svg') },
         { id: '#debrief-attackpath-svg', type: 'attackpath', tooltip: d3.select('#op-tooltip'), simulation: createForceSimulation('operation'), svg: d3.select('#debrief-attackpath-svg') },
         { id: '#debrief-tactic-svg', type: 'tactic', tooltip: d3.select('#op-tooltip'), simulation: createForceSimulation('operation'), svg: d3.select('#debrief-tactic-svg') },
         { id: '#debrief-technique-svg', type: 'technique', tooltip: d3.select('#op-tooltip'), simulation: createForceSimulation('operation'), svg: d3.select('#debrief-technique-svg') },

--- a/templates/debrief.html
+++ b/templates/debrief.html
@@ -63,8 +63,8 @@
                     <div class="is-flex graph-controls m-2">
                         <div class="select is-small mr-2">
                             <select x-model="selectedGraphType">
-                                <option value="graph">Default</option>
                                 <option value="attackpath">Attack Path</option>
+                                <option value="steps">Steps</option>
                                 <option value="tactic">Tactic</option>
                                 <option value="technique">Technique</option>
                             </select>
@@ -72,7 +72,7 @@
                         <button class="button is-small" @click="toggleLegend()" x-text="`${showGraphLegend ? 'Hide' : 'Show'} Legend`">Show Legend</button>
                     </div>
                     <!-- GRAPHS -->
-                    <svg id="debrief-graph-svg" x-ref="graph" class="op-svg debrief-svg" x-show="selectedGraphType === 'graph'"></svg>
+                    <svg id="debrief-steps-svg" x-ref="steps" class="op-svg debrief-svg" x-show="selectedGraphType === 'steps'"></svg>
                     <svg id="debrief-attackpath-svg" x-ref="attackpath" class="op-svg debrief-svg" x-show="selectedGraphType === 'attackpath'"></svg>
                     <svg id="debrief-tactic-svg" x-ref="tactic" class="op-svg debrief-svg" x-show="selectedGraphType === 'tactic'"></svg>
                     <svg id="debrief-technique-svg" x-ref="technique" class="op-svg debrief-svg" x-show="selectedGraphType === 'technique'"></svg>
@@ -468,7 +468,7 @@ function alpineDebrief() {
         logoFilename: '',
         logos: [],
 
-        selectedGraphType: 'graph',
+        selectedGraphType: 'attackpath',
         nodesOrderedByTime: {},
         showGraphLegend: true,
         isGraphPlaying: false,
@@ -520,8 +520,8 @@ function alpineDebrief() {
                 "main-summary",
                 "statistics",
                 "agents",
-                "default-graph",
                 "attackpath-graph",
+                "steps-graph",
                 "tactic-graph",
                 "technique-graph",
                 "fact-graph",
@@ -747,10 +747,10 @@ function alpineDebrief() {
         toggleSteps() {
             if (this.graphOptionSteps) {
                 document.querySelectorAll('#debrief-graph .link').forEach((el) => el.style.display = '');
-                document.querySelectorAll('#debrief-graph-svg .next_link').forEach((el) => el.style.display = '');
+                document.querySelectorAll('#debrief-steps-svg .next_link').forEach((el) => el.style.display = '');
             } else {
                 document.querySelectorAll('#debrief-graph .link').forEach((el) => el.style.display = 'none');
-                document.querySelectorAll('#debrief-graph-svg .next_link').forEach((el) => el.style.display = 'none');
+                document.querySelectorAll('#debrief-steps-svg .next_link').forEach((el) => el.style.display = 'none');
             }
         },
 
@@ -795,7 +795,7 @@ function alpineDebrief() {
             }
             
             this.nodesOrderedByTime = {};
-            this.nodesOrderedByTime["debrief-graph-svg"] = getSortedNodes("debrief-graph-svg");
+            this.nodesOrderedByTime["debrief-steps-svg"] = getSortedNodes("debrief-steps-svg");
             this.nodesOrderedByTime["debrief-attackpath-svg"] = getSortedNodes("debrief-attackpath-svg");
             this.nodesOrderedByTime["debrief-tactic-svg"] = getSortedNodes("debrief-tactic-svg");
             this.nodesOrderedByTime["debrief-technique-svg"] = getSortedNodes("debrief-technique-svg");


### PR DESCRIPTION
## Description

The proposed change renames the default graph to Steps in both the GUI and any references on the backend for consistency (previously referenced as "operations" graph). The graph display has been reordered to display the Attack Path graph first.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Opened a previously run operation in the debrief GUI, downloaded the PDF with all sections enabled and opened to verify the PDF was generated properly.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
