### PR TITLE
Fix "cell...too large" errors

### DIFF
--- a/app/debrief-sections/facts_table.py
+++ b/app/debrief-sections/facts_table.py
@@ -4,7 +4,7 @@ from reportlab.platypus.flowables import KeepTogetherSplitAtTop
 
 from plugins.debrief.app.utility.base_report_section import BaseReportSection
 
-TABLE_CHAR_LIMIT = 1800
+TABLE_CHAR_LIMIT = 1500
 
 
 class DebriefReportSection(BaseReportSection):


### PR DESCRIPTION
## Description

Fix errors like `"tallest cell ... too large on page ... in frame normal ... of template 'Later'"`, caused by fact values that are too long  to fit on a single page in the PDF.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added the below fact value to the `basic` fact source and tried to download the PDF. Tried with a limit of 1600 but still got the error. Also tested with reordering the facts in the fact source to test it in different positions on the page (if the long fact is the first one on a page, or last). Also tested with all the spaces removed.

```
Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident
    ,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi ,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,  cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.Atveroeosetaccusamusetiustoodiodignissimosducimusquiblanditiispraesentiumvoluptatumdelenitiatquecorruptiquosdoloresetquasmolestiasexcepturisintoccaecaticupiditatenonprovident,  similiquesuntinculpaquiofficiadeseruntmollitiaanimi,  idestlaborumetdolorumfuga.Etharumquidemrerumfacilisestetexpeditadistinctio.Namliberotempore,
    cumsolutanobisesteligendioptiocumquenihilimpeditquominusidquodmaximeplaceatfacerepossimus,  omnisvoluptasassumendaest,  omnisdolorrepellendus.
    Temporibusautemquibusdametautofficiisdebitisautrerumnecessitatibussaepeevenietutetvoluptatesrepudiandaesintetmolestiaenonrecusandae.Itaqueearumrerumhicteneturasapientedelectus,  utautreiciendisvoluptatibusmaioresaliasconsequaturautperferendisdoloribusasperioresrepellat.
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
