### PR TITLE
Patch XSS vulnerability in graph.js

### DIFF
--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -272,7 +272,7 @@ function writeGraph(graph) {
         let ret = '';
         switch (d['type']) {
             case 'operation':
-                ret += 'name: ' + d['name'] + '<br/>';
+                ret += 'name: ' + sanitize(d['name']) + '<br/>';
                 ret += 'op_id: ' + d['id'] + '<br/>';
                 ret += 'created: ' + d['timestamp'] + '<br/>';
                 break;
@@ -283,7 +283,7 @@ function writeGraph(graph) {
                 ret += 'created: ' + d['timestamp'] + '<br/>';
                 for (let attr in d['attrs']) {
                     if (attr != d['type']) {
-                        ret += attr + ': ' + d['attrs'][attr] + '<br/>';
+                        ret += sanitize(attr) + ': ' + sanitize(d['attrs'][attr]) + '<br/>';
                     }
                 }
                 break;
@@ -291,8 +291,8 @@ function writeGraph(graph) {
                 ret += d['timestamp'] ? 'created: ' + d['timestamp'] + '<br/>' : '';
                 for (let attr in d['attrs']) {
                     if (d['attrs'][attr] != null) {
-                        ret += attr + ': ';
-                        ret += attr == 'status' ? statusName(d['attrs'][attr]) : d['attrs'][attr];
+                        ret += sanitize(attr) + ': ';
+                        ret += attr == 'status' ? statusName(d['attrs'][attr]) : sanitize(d['attrs'][attr]);
                         ret += '<br/>';
                     }
                 }


### PR DESCRIPTION
## Description

When an operation's node was hovered over that contained an XSS in its name, the script was triggered. This PR mitigates this vulnerability by sanitizing the HTML to the tooltip of the node so all HTML within it is stripped just like in the operations page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

An operation with a XSS attack in it's name was created via the API (since one cannot be made via the GUI anymore). Debrief is then opened and said operation was selected. The graph type was then changed to "Tactic" so the operation node appeared, and hovering over the node no longer triggered the attack.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
