### PR TITLE
[VIRTS-4408] Changed UI to account for results being a dictionary

### DIFF
--- a/templates/debrief.html
+++ b/templates/debrief.html
@@ -321,8 +321,14 @@
                 <section class="modal-card-body">
                     <p>Command</p>
                     <pre x-text="command"></pre>
-                    <p>Output</p>
-                    <pre x-text="commandOutput"></pre>
+                    <p x-text="`Standard Output${commandOutput.stdout ? '' : ': Nothing to show'}`"></p>
+                    <template x-if="commandOutput != '' && commandOutput.stdout !== ''">
+                        <pre class="has-text-left white-space-pre-line" x-text="commandOutput.stdout"></pre>
+                    </template>
+                    <p x-text="`Standard Error${commandOutput.stderr ? '' : ': Nothing to show'}`"></p>
+                    <template x-if="commandOutput != '' && commandOutput.stderr !== ''">
+                        <pre class="has-text-left white-space-pre-line has-text-danger" x-text="commandOutput.stderr"></pre>
+                    </template>
                 </section>
                 <footer class="modal-card-foot">
                     <nav class="level">
@@ -592,8 +598,12 @@ function alpineDebrief() {
             };
             apiV2('POST', '/api/rest', requestBody).then((data) => {
                 if (data) {
-                    this.command = b64DecodeUnicode(data.link.command);
-                    this.commandOutput = b64DecodeUnicode(data.output);
+                    try {
+                        this.command = b64DecodeUnicode(data.link.command);
+                        this.commandOutput = JSON.parse(b64DecodeUnicode(data.output));
+                    } catch (error) { // occurs when data is not JSON
+                        this.commandOutput = '';
+                    }
                 } else {
                     this.command = 'No command to display';
                     this.commandOutput = '';

--- a/templates/debrief.html
+++ b/templates/debrief.html
@@ -603,6 +603,8 @@ function alpineDebrief() {
                         this.commandOutput = JSON.parse(b64DecodeUnicode(data.output));
                     } catch (error) { // occurs when data is not JSON
                         this.commandOutput = '';
+                        console.error(error);
+                        toast('Error getting command and/or command results.');
                     }
                 } else {
                     this.command = 'No command to display';


### PR DESCRIPTION
## Description

Updating Debrief UI to account for agent results being written as a dictionary (VIRTS-4148, VIRTS-4149)

Depends on https://github.com/mitre/caldera/pull/2662

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested with stdout, stderr, with neither, and with both.  Tested reports as well as UI.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
