### PR TITLE
[VIRTS-4674] Resolve Empty PDF Generation Issues

### DIFF
--- a/app/debrief-sections/facts_table.py
+++ b/app/debrief-sections/facts_table.py
@@ -4,7 +4,7 @@ from reportlab.platypus.flowables import KeepTogetherSplitAtTop
 
 from plugins.debrief.app.utility.base_report_section import BaseReportSection
 
-TABLE_CHAR_LIMIT = 1500
+TABLE_CHAR_LIMIT = 1100
 
 
 class DebriefReportSection(BaseReportSection):

--- a/app/debrief-sections/facts_table.py
+++ b/app/debrief-sections/facts_table.py
@@ -4,7 +4,7 @@ from reportlab.platypus.flowables import KeepTogetherSplitAtTop
 
 from plugins.debrief.app.utility.base_report_section import BaseReportSection
 
-TABLE_CHAR_LIMIT = 1100
+TABLE_CHAR_LIMIT = 1050
 
 
 class DebriefReportSection(BaseReportSection):


### PR DESCRIPTION
## Description
When running an operation that generates long facts, users were encountering an error when attempting to export the operation to a PDF. The issue was due to an extremely long fact value that caused the table row to span multiple pages, which caused in error in the `reportlab.platypus` library.

As row heights need to be dynamically generated, I reduced the `TABLE_CHAR_LIMIT` (the maximum length of a fact value) to something that would restrict the row to one page at the most. 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Prior to this update, the bug could be reproduced by the following steps:
1). Start agent and operation. When creating the operation. use the 'Discovery' adversary.
2). When the operation finished, go to Debrief, select the operation you just ran, and click `Download PDF Report`.
3). Ensure that the facts table is selected, and click download. The resulting PDF would be 0 bytes due to the error.

Now, the fact table will load correctly, and the PDF can be downloaded successfully.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
