### PR TITLE
Improve topology UI, PDF report, and table layouts

### DIFF
--- a/app/debrief-sections/facts_table.py
+++ b/app/debrief-sections/facts_table.py
@@ -143,5 +143,5 @@ class DebriefReportSection(BaseReportSection):
             fact_table_row = self._generate_fact_table_row(f, include_agent_links, link_by_id, op_source_id, white_traits)
             fact_data.append(fact_table_row)
 
-        # Slightly wider Source/Command columns
-        return self.generate_table(fact_data, [1*inch, 1.8*inch, .6*inch, 1.3*inch, 2.3*inch], escape_html=False)
+        # Score/Source at minimum width; Trait/Value/Command expand to fill
+        return self.generate_table(fact_data, [1.1*inch, 2.1*inch, .4*inch, .55*inch, 2.85*inch], escape_html=False)

--- a/app/debrief-sections/main_summary.py
+++ b/app/debrief-sections/main_summary.py
@@ -32,32 +32,4 @@ class DebriefReportSection(BaseReportSection):
             Paragraph(self.description, styles['Normal']),
         ]
 
-        # Campaign summary on cover page
-        operations = kwargs.get('operations', [])
-        if operations:
-            flowables.append(Spacer(1, 16))
-            summary = self._build_cover_summary(operations)
-            flowables.append(Paragraph(summary, styles['Normal']))
-
         return [KeepTogetherSplitAtTop(flowables)]
-
-    def _build_cover_summary(self, operations):
-        """Build a brief campaign summary for the cover page."""
-        op_names = ', '.join(f'<b>{o.name}</b>' for o in operations)
-
-        total_steps = 0
-        agents = set()
-        for op in operations:
-            for link in (getattr(op, 'chain', []) or []):
-                if not getattr(link, 'cleanup', 0):
-                    total_steps += 1
-            for agent in (getattr(op, 'agents', []) or []):
-                paw = getattr(agent, 'paw', None)
-                if paw:
-                    agents.add(paw)
-
-        lines = [
-            f'<b>Operations:</b> {op_names}',
-            f'<b>Agents:</b> {len(agents)} &nbsp;&nbsp; <b>Steps:</b> {total_steps}',
-        ]
-        return '<br/>'.join(lines)

--- a/app/debrief-sections/statistics.py
+++ b/app/debrief-sections/statistics.py
@@ -95,6 +95,8 @@ class DebriefReportSection(BaseReportSection):
             ('FONTNAME', (0, 1), (0, -1), 'Helvetica-Bold'),
             ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
             ('VALIGN', (0, 0), (-1, -1), 'TOP'),
+            ('LEFTPADDING', (0, 0), (-1, -1), 3),
+            ('RIGHTPADDING', (0, 0), (-1, -1), 3),
             ('INNERGRID', (0, 0), (-1, -1), 0.5, colors.white),
             ('BOX', (0, 0), (-1, -1), 0.5, colors.black),
         ]))

--- a/app/debrief-sections/step_output.py
+++ b/app/debrief-sections/step_output.py
@@ -2,6 +2,7 @@ import logging
 
 from html import escape
 from reportlab.lib.units import inch
+from reportlab.lib.styles import ParagraphStyle
 from reportlab.platypus import Paragraph
 from reportlab.platypus.flowables import KeepTogetherSplitAtTop
 
@@ -48,20 +49,23 @@ class DebriefReportSection(BaseReportSection):
             if not output:
                 continue
             if len(output) > OUTPUT_CHAR_LIMIT:
-                output = escape(output[:OUTPUT_CHAR_LIMIT]) + TRUNCATED_MSG
+                output_html = escape(output[:OUTPUT_CHAR_LIMIT]) + TRUNCATED_MSG
             else:
-                output = escape(output)
+                output_html = escape(output)
+            # Wrap output as a pre-built Paragraph so markup (TRUNCATED_MSG) is preserved
+            # while other cells use default escaping via escape_html=True
+            output_para = Paragraph(output_html, ParagraphStyle(name='Output', fontSize=8, wordWrap='CJK'))
             data.append([
                 getattr(link.ability, 'name', '') or '',
                 self.status_name(link.status),
                 link.paw,
-                output,
+                output_para,
             ])
 
         if len(data) == 1:
             return None  # no output to show
 
-        return self.generate_table(data, [1.2*inch, .6*inch, .6*inch, 4.6*inch], escape_html=False)
+        return self.generate_table(data, [1.2*inch, .6*inch, .6*inch, 4.6*inch])
 
     def _get_output(self, link):
         """Decode link output, returning empty string if unavailable."""

--- a/app/debrief-sections/step_output.py
+++ b/app/debrief-sections/step_output.py
@@ -28,13 +28,16 @@ class DebriefReportSection(BaseReportSection):
             return flowable_list
 
         for op in kwargs.get('operations', []):
+            table = self._generate_output_table(op)
+            if table is None:
+                continue  # skip section entirely when no output captured
             flowable_list.append(
                 KeepTogetherSplitAtTop([
-                    Paragraph(self.section_title % op.name.upper(), styles['Heading2']),
+                    Paragraph(self.section_title % escape(op.name.upper()), styles['Heading2']),
                     Paragraph(self.description, styles['Normal'])
                 ])
             )
-            flowable_list.append(self._generate_output_table(op))
+            flowable_list.append(table)
 
         return flowable_list
 
@@ -56,7 +59,7 @@ class DebriefReportSection(BaseReportSection):
             ])
 
         if len(data) == 1:
-            data.append(['No output captured', '', '', ''])
+            return None  # no output to show
 
         return self.generate_table(data, [1.2*inch, .6*inch, .6*inch, 4.6*inch], escape_html=False)
 

--- a/app/debrief-sections/step_output.py
+++ b/app/debrief-sections/step_output.py
@@ -48,7 +48,7 @@ class DebriefReportSection(BaseReportSection):
             if not output:
                 continue
             if len(output) > OUTPUT_CHAR_LIMIT:
-                output = output[:OUTPUT_CHAR_LIMIT] + TRUNCATED_MSG
+                output = escape(output[:OUTPUT_CHAR_LIMIT]) + TRUNCATED_MSG
             else:
                 output = escape(output)
             data.append([

--- a/app/debrief-sections/step_output.py
+++ b/app/debrief-sections/step_output.py
@@ -10,6 +10,7 @@ from plugins.debrief.app.utility.base_report_section import BaseReportSection
 
 OUTPUT_CHAR_LIMIT = 500
 TRUNCATED_MSG = '... <font color="maroon"><i>(output truncated)</i></font>'
+_OUTPUT_STYLE = ParagraphStyle(name='StepOutput', fontSize=8, wordWrap='CJK')
 
 
 class DebriefReportSection(BaseReportSection):
@@ -54,7 +55,7 @@ class DebriefReportSection(BaseReportSection):
                 output_html = escape(output)
             # Wrap output as a pre-built Paragraph so markup (TRUNCATED_MSG) is preserved
             # while other cells use default escaping via escape_html=True
-            output_para = Paragraph(output_html, ParagraphStyle(name='Output', fontSize=8, wordWrap='CJK'))
+            output_para = Paragraph(output_html, _OUTPUT_STYLE)
             data.append([
                 getattr(link.ability, 'name', '') or '',
                 self.status_name(link.status),

--- a/app/debrief-sections/steps_table.py
+++ b/app/debrief-sections/steps_table.py
@@ -47,5 +47,5 @@ class DebriefReportSection(BaseReportSection):
             ])
 
         return self.generate_table(steps, [
-            .7*inch, .55*inch, .55*inch, .65*inch, .85*inch, .75*inch, 2.45*inch, .5*inch
+            .7*inch, .6*inch, .5*inch, .65*inch, .9*inch, .8*inch, 2.45*inch, .4*inch
         ])

--- a/app/debrief-sections/tactic_technique_table.py
+++ b/app/debrief-sections/tactic_technique_table.py
@@ -199,8 +199,8 @@ class DebriefReportSection(BaseReportSection):
             ('BOX',        (0, 0), (-1, -1), 0.75, colors.black),
             ('INNERGRID',  (0, 0), (-1, -1), 0.25, colors.black),
 
-            ('LEFTPADDING',   (0, 0), (-1, -1), 4),
-            ('RIGHTPADDING',  (0, 0), (-1, -1), 4),
+            ('LEFTPADDING',   (0, 0), (-1, -1), 3),
+            ('RIGHTPADDING',  (0, 0), (-1, -1), 3),
             ('TOPPADDING',    (0, 0), (-1, -1), 0),
             ('BOTTOMPADDING', (0, 0), (-1, -1), 2),
         ]))

--- a/app/debrief-sections/ttps_detections.py
+++ b/app/debrief-sections/ttps_detections.py
@@ -27,14 +27,14 @@ class DebriefReportSection(BaseReportSection):
             self.styles = getSampleStyleSheet()
 
         self.DATA_COL_WIDTHS = [
-            0.53*inch,  # AN
-            0.60*inch,  # Platform
-            2.10*inch,  # Detection Statement
-            0.85*inch,  # Name
-            1.10*inch,  # Channel
-            1.20*inch,  # Data Component
-            1.41*inch,  # Field
-            1.70*inch,  # Description
+            0.50*inch,  # AN
+            0.55*inch,  # Platform
+            1.85*inch,  # Detection Statement
+            0.75*inch,  # Name
+            0.85*inch,  # Channel
+            1.25*inch,  # Data Component
+            0.85*inch,  # Field
+            2.89*inch,  # Description
         ]
         self.DATA_FULL_WIDTH = sum(self.DATA_COL_WIDTHS)
         self.cell_style = ParagraphStyle(
@@ -488,8 +488,8 @@ class DebriefReportSection(BaseReportSection):
             ('BOX',        (0, 0), (7, -1), 0.75, colors.black),
             ('INNERGRID',  (0, 0), (7, -1), 0.25, colors.black),
 
-            ('LEFTPADDING',   (0, 0), (7, -1), 4),
-            ('RIGHTPADDING',  (0, 0), (7, -1), 4),
+            ('LEFTPADDING',   (0, 0), (7, -1), 3),
+            ('RIGHTPADDING',  (0, 0), (7, -1), 3),
             ('BOTTOMPADDING', (0, 0), (7, -1), 2),
         ]
 

--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -258,8 +258,8 @@ class DebriefGui(BaseWorld):
         story_obj.append(Spacer(1, 36))
         styles = getSampleStyleSheet()
 
-        # Decide if Detections is the only section (controls first page orientation)
-        sections = list(sections or [])
+        # Filter out hidden sections server-side (defence in depth)
+        sections = [s for s in (sections or []) if s not in self._HIDDEN_SECTIONS]
         detections_only = (len(sections) == 1 and sections[0] == 'ttps-detections')
 
         # # Always render Detections last if present (unless it's the only section)

--- a/app/debrief_gui.py
+++ b/app/debrief_gui.py
@@ -190,6 +190,11 @@ class DebriefGui(BaseWorld):
         with open(filepath, 'wb') as f:
             f.write(content)
 
+    # D3 force-directed graph sections removed from PDF — their layouts are
+    # non-deterministic and unreadable in print. The equivalent table sections
+    # (steps-table, tactic-technique-table) convey the same data.
+    _HIDDEN_SECTIONS = {'steps-graph', 'tactic-graph', 'technique-graph', 'fact-graph'}
+
     def _load_report_sections(self, plugins):
         if not self.loaded_report_sections:
             for plugin in plugins:
@@ -204,7 +209,8 @@ class DebriefGui(BaseWorld):
                                 module_obj = module.DebriefReportSection()
                                 safe_id = re.sub('[^A-Za-z0-9-_:.]', '', re.sub(r'\s+', '-', module_obj.id))
                                 self.report_section_modules[safe_id] = module_obj
-                                self.report_section_names.append({'key': safe_id, 'name': module_obj.display_name})
+                                if safe_id not in self._HIDDEN_SECTIONS:
+                                    self.report_section_names.append({'key': safe_id, 'name': module_obj.display_name})
                             except Exception as e:
                                 self.log.error('Skipping debrief section %s due to error: %r', module_name, e)
             self.log.debug('Finished loading debrief report sections.')
@@ -325,9 +331,20 @@ class DebriefGui(BaseWorld):
                     for f in cover_flowables:
                         story_obj.append(f)
 
-            # ---- SECTIONS: append each section’s flowables ----
+            # ---- STATISTICS: render right after cover ----
+            stats_module = self.report_section_modules.get('statistics')
+            if stats_module and 'statistics' in sections:
+                self.log.debug('Generating statistics section (after cover)')
+                stats_flowables = await stats_module.generate_section_elements(
+                    styles, operations=operations, agents=agents,
+                    graph_files=graph_files, selected_sections=sections
+                )
+                for f in stats_flowables:
+                    story_obj.append(f)
+
+            # ---- SECTIONS: append each section's flowables ----
             for section in sections:
-                if section == 'main-summary':
+                if section in ('main-summary', 'statistics'):
                     continue
 
                 section_module = self.report_section_modules.get(section)

--- a/app/debrief_svc.py
+++ b/app/debrief_svc.py
@@ -349,30 +349,21 @@ class DebriefService(BaseService):
                             ))
                             agents_with_origin.add(agent.paw)
 
-        # Second: derive edges from chain order for agents without origin_link_id
-        # When the chain switches from agent A to agent B, that implies a hop A→B
+        # Second: agents without origin_link_id connect directly to C2
+        # Only agents with an explicit origin_link_id (lateral movement) get
+        # agent-to-agent edges (handled above). All others beacon to C2 directly.
         seen_paws = set()
-        edge_pairs = set()  # avoid duplicate edges
-        prev_paw = None
+        edge_pairs = set()
         for item in replay_sequence:
             paw = item['paw']
             if paw not in seen_paws:
-                if prev_paw is None:
-                    # First agent seen → C2 edge
+                if paw not in agents_with_origin:
                     edge_pair = ('c2', paw)
                     if edge_pair not in edge_pairs:
                         edges.append(dict(source='c2', target=paw,
                                           type='initial_access', technique='Initial Access'))
                         edge_pairs.add(edge_pair)
-                elif paw not in agents_with_origin:
-                    # New agent without explicit origin → infer hop from previous agent
-                    edge_pair = (prev_paw, paw)
-                    if edge_pair not in edge_pairs:
-                        edges.append(dict(source=prev_paw, target=paw,
-                                          type='lateral_movement', technique='Inferred from chain order'))
-                        edge_pairs.add(edge_pair)
                 seen_paws.add(paw)
-            prev_paw = paw
 
         # Third: fallback — if no chain at all, create edges from agent order
         # This handles fabricated operations where agents exist but no steps ran

--- a/app/objects/c_story.py
+++ b/app/objects/c_story.py
@@ -1,4 +1,5 @@
 import html
+import os
 
 from lxml import etree as ET
 from reportlab.lib import colors
@@ -118,14 +119,19 @@ class Story:
 
     SVG_NS = 'http://www.w3.org/2000/svg'
     _icon_cache = {}
+    # Allowlisted icon filenames → safe on-disk paths
+    _ICON_DIR = os.path.join('plugins', 'debrief', 'static', 'img')
+    _ALLOWED_ICONS = {'linux.svg', 'windows.svg', 'darwin.svg', 'cloud.svg', 'unknown.svg'}
 
     @classmethod
-    def _load_icon_svg(cls, icon_path):
-        """Read an SVG icon file and return its root element for inlining."""
-        if icon_path in cls._icon_cache:
-            return cls._icon_cache[icon_path]
+    def _load_icon_svg(cls, icon_key):
+        """Read an allowlisted SVG icon file and return its root element."""
+        if icon_key in cls._icon_cache:
+            return cls._icon_cache[icon_key]
+        if icon_key not in cls._ALLOWED_ICONS:
+            return None
         try:
-            import os
+            icon_path = os.path.join(cls._ICON_DIR, icon_key)
             if not os.path.isfile(icon_path):
                 return None
             parser = ET.XMLParser(
@@ -133,8 +139,8 @@ class Story:
                 dtd_validation=False, load_dtd=False,
             )
             tree = ET.parse(icon_path, parser)
-            cls._icon_cache[icon_path] = tree.getroot()
-            return cls._icon_cache[icon_path]
+            cls._icon_cache[icon_key] = tree.getroot()
+            return cls._icon_cache[icon_key]
         except Exception:
             return None
 
@@ -150,25 +156,24 @@ class Story:
         root = svg.getroot()
         ns = Story.SVG_NS
 
-        # Inline external <image> icons that have data-icon-path attributes
-        for img_el in root.iter('{%s}image' % ns):
-            icon_path = img_el.get('data-icon-path')
-            if not icon_path:
+        # Inline external <image> icons that have data-icon-key attributes
+        import copy as copy_mod
+        for img_el in list(root.iter('{%s}image' % ns)):
+            icon_key = img_el.get('data-icon-key')
+            if not icon_key:
                 continue
 
-            icon_root = Story._load_icon_svg(icon_path)
+            icon_root = Story._load_icon_svg(icon_key)
             if icon_root is None:
                 continue
 
-            # Get placement from the <image> element
             x = float(img_el.get('x', 0))
             y = float(img_el.get('y', 0))
             w = float(img_el.get('width', 40))
             h = float(img_el.get('height', 40))
 
-            # Create an inline <svg> with the icon's viewBox and content
             vb = icon_root.get('viewBox', '0 0 512 512')
-            inline_svg = ET.SubElement(img_el.getparent(), '{%s}svg' % ns)
+            inline_svg = ET.Element('{%s}svg' % ns)
             inline_svg.set('data-inlined-icon', 'true')
             inline_svg.set('viewBox', vb)
             inline_svg.set('x', str(x))
@@ -176,13 +181,13 @@ class Story:
             inline_svg.set('width', str(w))
             inline_svg.set('height', str(h))
 
-            # Copy all children from the icon SVG
-            import copy
             for child in icon_root:
-                inline_svg.append(copy.deepcopy(child))
+                inline_svg.append(copy_mod.deepcopy(child))
 
-            # Remove the original <image> element
-            img_el.getparent().remove(img_el)
+            # Insert at the same position as the <image> to preserve z-order
+            parent = img_el.getparent()
+            parent.insert(list(parent).index(img_el), inline_svg)
+            parent.remove(img_el)
 
         # Legacy D3 graph icon adjustment (skip inlined topology icons)
         for icon_svg in root.iter('{%s}svg' % ns):

--- a/app/objects/c_story.py
+++ b/app/objects/c_story.py
@@ -169,6 +169,7 @@ class Story:
             # Create an inline <svg> with the icon's viewBox and content
             vb = icon_root.get('viewBox', '0 0 512 512')
             inline_svg = ET.SubElement(img_el.getparent(), '{%s}svg' % ns)
+            inline_svg.set('data-inlined-icon', 'true')
             inline_svg.set('viewBox', vb)
             inline_svg.set('x', str(x))
             inline_svg.set('y', str(y))
@@ -183,9 +184,11 @@ class Story:
             # Remove the original <image> element
             img_el.getparent().remove(img_el)
 
-        # Legacy D3 graph icon adjustment
+        # Legacy D3 graph icon adjustment (skip inlined topology icons)
         for icon_svg in root.iter('{%s}svg' % ns):
             if icon_svg.get('id') == 'copy-svg':
+                continue
+            if icon_svg.get('data-inlined-icon'):
                 continue
             viewbox_attr = icon_svg.get('viewBox')
             if not viewbox_attr:

--- a/app/objects/c_story.py
+++ b/app/objects/c_story.py
@@ -116,6 +116,28 @@ class Story:
         im.drawOn(canvas, page_w - im.drawWidth - 10,
                   page_h - im.drawHeight - 10)
 
+    SVG_NS = 'http://www.w3.org/2000/svg'
+    _icon_cache = {}
+
+    @classmethod
+    def _load_icon_svg(cls, icon_path):
+        """Read an SVG icon file and return its root element for inlining."""
+        if icon_path in cls._icon_cache:
+            return cls._icon_cache[icon_path]
+        try:
+            import os
+            if not os.path.isfile(icon_path):
+                return None
+            parser = ET.XMLParser(
+                resolve_entities=False, no_network=True,
+                dtd_validation=False, load_dtd=False,
+            )
+            tree = ET.parse(icon_path, parser)
+            cls._icon_cache[icon_path] = tree.getroot()
+            return cls._icon_cache[icon_path]
+        except Exception:
+            return None
+
     @staticmethod
     def adjust_icon_svgs(path):
         parser = ET.XMLParser(
@@ -125,7 +147,44 @@ class Story:
             load_dtd=False,
         )
         svg = ET.parse(path, parser)
-        for icon_svg in svg.getroot().iter("{http://www.w3.org/2000/svg}svg"):
+        root = svg.getroot()
+        ns = Story.SVG_NS
+
+        # Inline external <image> icons that have data-icon-path attributes
+        for img_el in root.iter('{%s}image' % ns):
+            icon_path = img_el.get('data-icon-path')
+            if not icon_path:
+                continue
+
+            icon_root = Story._load_icon_svg(icon_path)
+            if icon_root is None:
+                continue
+
+            # Get placement from the <image> element
+            x = float(img_el.get('x', 0))
+            y = float(img_el.get('y', 0))
+            w = float(img_el.get('width', 40))
+            h = float(img_el.get('height', 40))
+
+            # Create an inline <svg> with the icon's viewBox and content
+            vb = icon_root.get('viewBox', '0 0 512 512')
+            inline_svg = ET.SubElement(img_el.getparent(), '{%s}svg' % ns)
+            inline_svg.set('viewBox', vb)
+            inline_svg.set('x', str(x))
+            inline_svg.set('y', str(y))
+            inline_svg.set('width', str(w))
+            inline_svg.set('height', str(h))
+
+            # Copy all children from the icon SVG
+            import copy
+            for child in icon_root:
+                inline_svg.append(copy.deepcopy(child))
+
+            # Remove the original <image> element
+            img_el.getparent().remove(img_el)
+
+        # Legacy D3 graph icon adjustment
+        for icon_svg in root.iter('{%s}svg' % ns):
             if icon_svg.get('id') == 'copy-svg':
                 continue
             viewbox_attr = icon_svg.get('viewBox')
@@ -133,9 +192,15 @@ class Story:
                 continue
             viewbox = [int(float(val)) for val in viewbox_attr.split()]
             aspect = viewbox[2] / viewbox[3]
-            icon_svg.set('width', str(round(float(icon_svg.get('height')) * aspect)))
-            if not icon_svg.get('id') or 'legend' not in icon_svg.get('id'):
-                icon_svg.set('x', '-' + str(int(icon_svg.get('width')) / 2))
+            height = icon_svg.get('height')
+            if height and not icon_svg.get('data-icon-path'):
+                try:
+                    icon_svg.set('width', str(round(float(height) * aspect)))
+                    if not icon_svg.get('id') or 'legend' not in icon_svg.get('id'):
+                        icon_svg.set('x', '-' + str(int(icon_svg.get('width')) / 2))
+                except (ValueError, TypeError):
+                    pass
+
         with open(path, 'wb') as f:
             svg.write(f)
 

--- a/app/utility/base_report_section.py
+++ b/app/utility/base_report_section.py
@@ -81,6 +81,8 @@ class BaseReportSection:
             ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
             ('FONTSIZE', (0, 0), (-1, 0), 9),
             ('BOTTOMPADDING', (0, 0), (-1, 0), 4),
+            ('LEFTPADDING', (0, 0), (-1, -1), 3),
+            ('RIGHTPADDING', (0, 0), (-1, -1), 3),
             ('FONTSIZE', (0, 1), (-1, -1), 8),
             ('TOPPADDING', (0, 1), (-1, -1), 2),
             ('BOTTOMPADDING', (0, 1), (-1, -1), 2),

--- a/gui/views/debrief.vue
+++ b/gui/views/debrief.vue
@@ -953,10 +953,11 @@ export default {
                     edgesGroup.setAttribute('class', 'topo-edges');
                     // Insert before hosts so edges render behind icons
                     const hostsGroup = newSvg.querySelector('.topo-hosts');
-                    if (hostsGroup) {
-                        newSvg.querySelector('svg') ? newSvg.insertBefore(edgesGroup, hostsGroup) : null;
+                    if (hostsGroup && hostsGroup.parentNode === newSvg) {
+                        newSvg.insertBefore(edgesGroup, hostsGroup);
+                    } else {
+                        newSvg.appendChild(edgesGroup);
                     }
-                    newSvg.appendChild(edgesGroup);
                 }
                 // Clear any existing edges (may be stale from v-if)
                 edgesGroup.innerHTML = '';

--- a/gui/views/debrief.vue
+++ b/gui/views/debrief.vue
@@ -930,13 +930,14 @@ export default {
                     el.setAttribute('stroke-width', '2');
                 });
 
-                // Remove image icons — the Python backend will inline them from disk
+                // Tag image icons with a safe icon key for the Python backend to inline
+                const allowedIcons = new Set(['linux.svg', 'windows.svg', 'darwin.svg', 'cloud.svg', 'unknown.svg']);
                 newSvg.querySelectorAll('.topo-host-icon').forEach((el) => {
-                    // Convert href to a relative file path the backend can resolve
                     const href = el.getAttribute('href') || '';
-                    // /debrief/img/linux.svg → plugins/debrief/static/img/linux.svg
-                    const filePath = href.replace('/debrief/', 'plugins/debrief/static/');
-                    el.setAttribute('data-icon-path', filePath);
+                    const iconName = (href.split('/').pop() || '').trim();
+                    if (allowedIcons.has(iconName)) {
+                        el.setAttribute('data-icon-key', iconName);
+                    }
                 });
 
                 // Make zone bands visible on white background

--- a/gui/views/debrief.vue
+++ b/gui/views/debrief.vue
@@ -568,7 +568,6 @@ export default {
         topoVisitedHosts: new Set(),
         topoRevealedHosts: new Set(),
         topoNewestEdge: -1,
-        topoBeaconEdge: -1,
         topoBeaconEdges: new Set(),
         topoBeaconDotT: {},  // edgeIdx -> t value (0=source, 1=target)
         topoBeaconDotColor: '#44AA99',  // current beacon dot color (green=success, red=failure)
@@ -694,7 +693,7 @@ export default {
                 this.topoVisitedHosts = new Set();
                 this.topoActiveHost = null;
                 this.topoNewestEdge = -1;
-                this.topoBeaconEdge = -1;
+
                 this.topoCommandEdges = new Set();
                 this.topoCommandDotT = {};
                 this.topoStepCounts = {};
@@ -1158,7 +1157,7 @@ export default {
             this.topoSelectedHost = null;
             this.topoActiveHost = null;
             this.topoNewestEdge = -1;
-            this.topoBeaconEdge = -1;
+
             this.topoCommandEdges = new Set();
             this.topoCommandDotT = {};
             this.topoStepCounts = {};
@@ -1177,7 +1176,7 @@ export default {
                 this.topoVisitedHosts = new Set();
                 this.topoActiveHost = null;
                 this.topoNewestEdge = -1;
-                this.topoBeaconEdge = -1;
+
                 this.topoCommandEdges = new Set();
                 this.topoCommandDotT = {};
                 this.topoStepCounts = {};
@@ -1241,7 +1240,7 @@ export default {
             this.topoVisitedHosts = new Set();
             this.topoActiveHost = null;
             this.topoNewestEdge = -1;
-            this.topoBeaconEdge = -1;
+
             this.topoCommandEdges = new Set();
             this.topoCommandDotT = {};
             this.topoStepCounts = {};
@@ -1261,7 +1260,7 @@ export default {
             this.topoVisitedHosts = new Set(allHosts);
             this.topoActiveHost = null;
             this.topoNewestEdge = -1;
-            this.topoBeaconEdge = -1;
+
             this.topoCommandEdges = new Set();
             this.topoCommandDotT = {};
             this.topoStepCounts = {};
@@ -1349,7 +1348,7 @@ export default {
 
             // If this is a newly revealed host, show the edge + batch-reveal discovered hosts
             this.topoNewestEdge = -1;
-            this.topoBeaconEdge = -1;
+
             this.topoCommandEdges = new Set();
             this.topoCommandDotT = {};
             if (!wasRevealed) {

--- a/gui/views/debrief.vue
+++ b/gui/views/debrief.vue
@@ -104,7 +104,7 @@ div.d3-tooltip {
 .topo-split {
     display: flex;
     gap: 0;
-    min-height: 450px;
+    min-height: 200px;
 }
 
 .topo-main-canvas {
@@ -115,7 +115,8 @@ div.d3-tooltip {
     background: #121212;
     border-radius: 6px;
     overflow: auto;
-    min-height: 250px;
+    min-height: 200px;
+    max-height: 55vh;
     border: 1px solid #2a2a3e;
     position: relative;
     flex: 1;
@@ -123,8 +124,8 @@ div.d3-tooltip {
 
 .topo-svg {
     width: 100%;
-    height: 100%;
-    min-height: 400px;
+    height: auto;
+    max-height: 55vh;
 }
 
 /* Zone bands */
@@ -554,7 +555,7 @@ export default {
         // Replay tab
         replayCursor: -1,
         replayPlaying: false,
-        replaySpeed: 2000,
+        replaySpeed: 600,
         replayInterval: null,
         replayExpandedIdx: -1,
         replayHoverIdx: -1,
@@ -570,6 +571,9 @@ export default {
         topoBeaconEdge: -1,
         topoBeaconEdges: new Set(),
         topoBeaconDotT: {},  // edgeIdx -> t value (0=source, 1=target)
+        topoBeaconDotColor: '#44AA99',  // current beacon dot color (green=success, red=failure)
+        topoCommandEdges: new Set(),    // edges with an active command dot (C2→host)
+        topoCommandDotT: {},            // edgeIdx -> t value for command dot
         topoExpandedStep: null,
         topoStepCounts: {},
         topoShowAll: false,    // true = static full view, false = progressive replay
@@ -691,6 +695,8 @@ export default {
                 this.topoActiveHost = null;
                 this.topoNewestEdge = -1;
                 this.topoBeaconEdge = -1;
+                this.topoCommandEdges = new Set();
+                this.topoCommandDotT = {};
                 this.topoStepCounts = {};
                 this.topoShowAll = false;
                 this.replayCursor = -1;
@@ -780,6 +786,12 @@ export default {
             let index = this.activeReportSections.indexOf(section);
             index >= 0 ? this.activeReportSections.splice(index, 1) : this.activeReportSections.push(section);
         },
+        selectAllReportSections() {
+            this.activeReportSections = this.reportSections.map(s => s.key);
+        },
+        deselectAllReportSections() {
+            this.activeReportSections = [];
+        },
 
         toggleLegend() {
             this.showGraphLegend = !this.showGraphLegend;
@@ -811,10 +823,10 @@ export default {
             });
         },
 
-        downloadPDF() {
+        async downloadPDF() {
             let requestBody = {
                 'operations': [this.selectedOperationId],
-                'graphs': this.getGraphData(),
+                'graphs': await this.getGraphData(),
                 'report-sections': this.activeReportSections,
                 'header-logo': this.logoFilename
             };
@@ -869,7 +881,7 @@ export default {
             downloadAnchorNode.remove();
         },
 
-        getGraphData() {
+        async getGraphData() {
             let encodedGraphs = {}
 
             // Capture the topology SVG as the main graph for PDF
@@ -883,7 +895,8 @@ export default {
                     this.topoRevealedHosts = allHosts;
                 }
 
-                this.$nextTick(() => {});  // let Vue render
+                // Wait for Vue to re-render with all hosts/edges revealed
+                await this.$nextTick();
 
                 let newSvg = topoSvg.cloneNode(true);
                 newSvg.setAttribute('id', 'copy-svg');
@@ -899,35 +912,72 @@ export default {
                 var viewBox = [bbox.x - 10, bbox.y - 10, bbox.width + 20, bbox.height + 20].join(' ');
                 newSvg.setAttribute('viewBox', viewBox);
 
-                // Fix text colors for PDF (dark background → light text won't work on white PDF)
-                newSvg.querySelectorAll('text').forEach((el) => {
+                // Fix text colors for PDF
+                newSvg.querySelectorAll('.topo-zone-label').forEach((el) => {
                     el.style.fill = '#333';
                 });
+                newSvg.querySelectorAll('.topo-host-label').forEach((el) => {
+                    el.style.fill = '#333';
+                });
+                newSvg.querySelectorAll('.topo-host-ip').forEach((el) => {
+                    el.style.fill = '#666';
+                });
 
-                // Make host backgrounds visible on white
+                // Light circles with dark border for print
                 newSvg.querySelectorAll('.topo-host-bg').forEach((el) => {
-                    el.setAttribute('fill', '#e8e8f0');
-                    el.setAttribute('stroke', '#666');
+                    el.setAttribute('fill', '#e8eaf0');
+                    el.setAttribute('stroke', '#555');
+                    el.setAttribute('stroke-width', '2');
+                });
+
+                // Remove image icons — the Python backend will inline them from disk
+                newSvg.querySelectorAll('.topo-host-icon').forEach((el) => {
+                    // Convert href to a relative file path the backend can resolve
+                    const href = el.getAttribute('href') || '';
+                    // /debrief/img/linux.svg → plugins/debrief/static/img/linux.svg
+                    const filePath = href.replace('/debrief/', 'plugins/debrief/static/');
+                    el.setAttribute('data-icon-path', filePath);
                 });
 
                 // Make zone bands visible on white background
                 newSvg.querySelectorAll('.topo-zone').forEach((el) => {
-                    el.setAttribute('stroke', '#999');
-                    el.setAttribute('fill', el.getAttribute('fill').replace(/[\d.]+\)$/, '0.15)'));
+                    el.setAttribute('stroke', '#888');
+                    el.setAttribute('stroke-width', '1.5');
+                    el.setAttribute('fill', 'rgba(200, 200, 210, 0.25)');
                 });
 
-                // Make edges darker for print
-                newSvg.querySelectorAll('.topo-edge').forEach((el) => {
-                    el.setAttribute('stroke', '#888');
+                // Inject edge paths directly — v-if may not have rendered them due to Set reactivity
+                let edgesGroup = newSvg.querySelector('.topo-edges');
+                if (!edgesGroup) {
+                    edgesGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+                    edgesGroup.setAttribute('class', 'topo-edges');
+                    // Insert before hosts so edges render behind icons
+                    const hostsGroup = newSvg.querySelector('.topo-hosts');
+                    if (hostsGroup) {
+                        newSvg.querySelector('svg') ? newSvg.insertBefore(edgesGroup, hostsGroup) : null;
+                    }
+                    newSvg.appendChild(edgesGroup);
+                }
+                // Clear any existing edges (may be stale from v-if)
+                edgesGroup.innerHTML = '';
+                // Add all computed edges
+                this.topoEdges.forEach((edge) => {
+                    if (edge.path) {
+                        const pathEl = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+                        pathEl.setAttribute('d', edge.path);
+                        pathEl.setAttribute('fill', 'none');
+                        pathEl.setAttribute('stroke', '#555');
+                        pathEl.setAttribute('stroke-width', '2');
+                        pathEl.setAttribute('stroke-dasharray', '6 4');
+                        edgesGroup.appendChild(pathEl);
+                    }
                 });
 
                 // Remove glow/beacon animations
                 newSvg.querySelectorAll('.topo-glow, .topo-beacon-dot, .topo-pulse').forEach((el) => el.remove());
 
-                // Remove icon filter (invert) for PDF — icons are already black
-                newSvg.querySelectorAll('.topo-host-icon').forEach((el) => {
-                    el.style.filter = 'none';
-                });
+                // Remove tooltip/hover elements not needed in PDF
+                newSvg.querySelectorAll('.topo-tooltip').forEach((el) => el.remove());
 
                 let serializedSvg = new XMLSerializer().serializeToString(newSvg);
                 let encodedData = window.btoa(unescape(encodeURIComponent(serializedSvg)));
@@ -941,28 +991,9 @@ export default {
                 this.topoRevealedHosts = wasRevealed;
             }
 
-            // Also capture old D3 SVGs for backward compatibility
-            document.querySelectorAll('.debrief-svg').forEach((svg) => {
-                let newSvg = svg.cloneNode(true);
-                newSvg.setAttribute('id', 'copy-svg');
-                document.getElementById('copy').appendChild(newSvg);
-                document.querySelectorAll('#copy-svg .container').forEach((container) => container.setAttribute('transform', 'scale(5)'));
-                var copy = document.getElementById('copy-svg');
-                if (copy.style.display == 'none') copy.style.display = '';
-                try {
-                    var bbox = copy.getBBox();
-                    var viewBox = [bbox.x - 10, bbox.y - 10, bbox.width + 20, bbox.height + 20].join(' ');
-                    copy.setAttribute('viewBox', viewBox);
-                } catch(e) {}
-                document.querySelectorAll('#copy-svg text').forEach((el) => el.style.fill = '#333');
-                let serializedSvg = new XMLSerializer().serializeToString(copy);
-                let encodedData = window.btoa(serializedSvg);
-                let graphKey = svg.id.split('-')[1];
-                if (!encodedGraphs[graphKey]) {
-                    encodedGraphs[graphKey] = encodedData;
-                }
-                document.getElementById('copy').innerHTML = '';
-            });
+            // D3 force-directed graphs (steps, tactic, technique) are omitted from
+            // PDF — their random layouts produce poor print output. The corresponding
+            // table sections already convey the same information in a readable format.
 
             return encodedGraphs;
         },
@@ -1126,6 +1157,8 @@ export default {
             this.topoActiveHost = null;
             this.topoNewestEdge = -1;
             this.topoBeaconEdge = -1;
+            this.topoCommandEdges = new Set();
+            this.topoCommandDotT = {};
             this.topoStepCounts = {};
             this.topoShowAll = false;
             // Reset to C2 only — progressive reveal starts from here
@@ -1143,6 +1176,8 @@ export default {
                 this.topoActiveHost = null;
                 this.topoNewestEdge = -1;
                 this.topoBeaconEdge = -1;
+                this.topoCommandEdges = new Set();
+                this.topoCommandDotT = {};
                 this.topoStepCounts = {};
             }
             this.replayPlaying = true;
@@ -1150,16 +1185,25 @@ export default {
                 this.replayCursor++;
                 const prevRevealed = new Set(this.topoRevealedHosts);
                 this.replayUpdateTopo();
-                // Check if a new host was just revealed
                 const seq = this.topoData.replay_sequence || [];
                 const item = seq[this.replayCursor];
                 const paw = item ? item.paw : null;
                 const isNewHost = paw && !prevRevealed.has(paw);
+                const step = item ? (item.step || {}) : {};
+                const stepStatus = step.status != null ? step.status : 0;
+
                 if (isNewHost && this.replayPlaying) {
-                    // Wait a moment to show the host, then beacon back to C2
-                    await this.sleep(400);
+                    // New host: show edge appearing, brief pause, then beacon back
+                    await this.sleep(200);
                     if (this.replayPlaying) {
-                        await this.replayBeaconToC2(paw);
+                        await this.replayBeaconToC2(paw, stepStatus);
+                    }
+                } else if (paw && this.replayPlaying) {
+                    // Existing host: animate C2 sending command, then host beaconing result
+                    await this.replayCommandToHost(paw);
+                    if (this.replayPlaying) {
+                        await this.sleep(80);
+                        await this.replayBeaconToC2(paw, stepStatus);
                     }
                 }
                 // Wait between steps
@@ -1196,6 +1240,8 @@ export default {
             this.topoActiveHost = null;
             this.topoNewestEdge = -1;
             this.topoBeaconEdge = -1;
+            this.topoCommandEdges = new Set();
+            this.topoCommandDotT = {};
             this.topoStepCounts = {};
         },
 
@@ -1214,6 +1260,8 @@ export default {
             this.topoActiveHost = null;
             this.topoNewestEdge = -1;
             this.topoBeaconEdge = -1;
+            this.topoCommandEdges = new Set();
+            this.topoCommandDotT = {};
             this.topoStepCounts = {};
             for (const [paw, steps] of Object.entries(this.topoData.steps_by_host || {})) {
                 this.topoStepCounts[paw] = steps.length;
@@ -1300,6 +1348,8 @@ export default {
             // If this is a newly revealed host, show the edge + batch-reveal discovered hosts
             this.topoNewestEdge = -1;
             this.topoBeaconEdge = -1;
+            this.topoCommandEdges = new Set();
+            this.topoCommandDotT = {};
             if (!wasRevealed) {
                 const edgeIdx = this.topoEdges.findIndex(e => e.target === paw);
                 if (edgeIdx >= 0) {
@@ -1342,7 +1392,7 @@ export default {
             }
         },
 
-        // Compute position of green dot along an edge
+        // Compute position of beacon dot along an edge (target→source direction: host back to C2)
         topoBeaconDotPos(edgeIdx) {
             const t = this.topoBeaconDotT[edgeIdx] || 0;
             const edge = this.topoEdges[edgeIdx];
@@ -1352,18 +1402,71 @@ export default {
             const src = hostMap[edge.source];
             const tgt = hostMap[edge.target];
             if (!src || !tgt) return { x: 0, y: 0 };
-            // Interpolate along the edge (target→source direction, so t=0 is target, t=1 is source)
+            // t=0 is target (host), t=1 is source (C2 direction)
             return {
                 x: tgt.x + (src.x - tgt.x) * t,
                 y: tgt.y + (src.y - tgt.y) * t,
             };
         },
 
-        // Animate green dot hopping along each edge from new host back to C2
-        async replayBeaconToC2(paw) {
+        // Compute position of command dot along an edge (source→target direction: C2 to host)
+        topoCommandDotPos(edgeIdx) {
+            const t = this.topoCommandDotT[edgeIdx] || 0;
+            const edge = this.topoEdges[edgeIdx];
+            if (!edge) return { x: 0, y: 0 };
+            const hostMap = {};
+            this.topoHosts.forEach(h => { hostMap[h.id] = h; });
+            const src = hostMap[edge.source];
+            const tgt = hostMap[edge.target];
+            if (!src || !tgt) return { x: 0, y: 0 };
+            // t=0 is source (C2), t=1 is target (host)
+            return {
+                x: src.x + (tgt.x - src.x) * t,
+                y: src.y + (tgt.y - src.y) * t,
+            };
+        },
+
+        // Animate command dot from C2 to host along the path
+        async replayCommandToHost(paw) {
             if (!this.topoData || !this.topoData.path_to_c2) return;
             const pathHosts = this.topoData.path_to_c2[paw];
             if (!pathHosts || pathHosts.length < 2) return;
+
+            // path_to_c2 is [host, ..., c2], so reverse for C2→host direction
+            const reversed = [...pathHosts].reverse();
+            for (let i = 0; i < reversed.length - 1; i++) {
+                if (!this.replayPlaying && i > 0) break;
+                const from = reversed[i];
+                const to = reversed[i + 1];
+
+                const edgeIdx = this.topoEdges.findIndex(e =>
+                    (e.source === from && e.target === to) || (e.source === to && e.target === from)
+                );
+                if (edgeIdx < 0) continue;
+
+                this.topoCommandEdges = new Set(this.topoCommandEdges);
+                this.topoCommandEdges.add(edgeIdx);
+                this.topoCommandDotT = { ...this.topoCommandDotT, [edgeIdx]: 0 };
+
+                const steps = 8;
+                for (let s = 0; s <= steps; s++) {
+                    this.topoCommandDotT = { ...this.topoCommandDotT, [edgeIdx]: s / steps };
+                    await this.sleep(20);
+                }
+
+                this.topoCommandEdges = new Set(this.topoCommandEdges);
+                this.topoCommandEdges.delete(edgeIdx);
+            }
+        },
+
+        // Animate beacon dot from host back to C2, colored by status
+        async replayBeaconToC2(paw, status) {
+            if (!this.topoData || !this.topoData.path_to_c2) return;
+            const pathHosts = this.topoData.path_to_c2[paw];
+            if (!pathHosts || pathHosts.length < 2) return;
+
+            // Set beacon color based on step status (0 = success, 1 = failure)
+            this.topoBeaconDotColor = (status === 0 || status === -3) ? '#44AA99' : '#CC3311';
 
             for (let i = 0; i < pathHosts.length - 1; i++) {
                 if (!this.replayPlaying && i > 0) break;
@@ -1375,19 +1478,16 @@ export default {
                 );
                 if (edgeIdx < 0) continue;
 
-                // Show dot on this edge and animate t from 0 to 1
                 this.topoBeaconEdges = new Set(this.topoBeaconEdges);
                 this.topoBeaconEdges.add(edgeIdx);
                 this.topoBeaconDotT = { ...this.topoBeaconDotT, [edgeIdx]: 0 };
 
-                // Animate in steps for visible hopping
-                const steps = 14;
+                const steps = 8;
                 for (let s = 0; s <= steps; s++) {
                     this.topoBeaconDotT = { ...this.topoBeaconDotT, [edgeIdx]: s / steps };
-                    await this.sleep(45);
+                    await this.sleep(20);
                 }
 
-                // Remove dot from this edge
                 this.topoBeaconEdges = new Set(this.topoBeaconEdges);
                 this.topoBeaconEdges.delete(edgeIdx);
             }
@@ -1454,7 +1554,7 @@ export default {
             const fullBandW = 160;
             const emptyBandW = 60;   // narrow for subnets with no agents
             const hostSpacing = 110;
-            const c2Width = 80;
+            const c2Width = 100;  // fixed space reserved for C2 icon + label
             let xCursor = c2Width + padding;
             return subnets.map((s, si) => {
                 const hosts_data = this.topoData.hosts || {};
@@ -1516,9 +1616,9 @@ export default {
                 });
             });
 
-            // C2 node on the left
+            // C2 node on the left — centered in reserved C2 area (100px wide)
             const svgH = this.topoSvgHeight;
-            hostPositions['c2'] = { x: 30, y: svgH / 2 };
+            hostPositions['c2'] = { x: 50, y: svgH / 2 };
 
             Object.entries(hosts).forEach(([id, host]) => {
                 const pos = hostPositions[id] || { x: 50, y: svgH / 2 };
@@ -1554,16 +1654,16 @@ export default {
             return `0 0 ${w} ${h}`;
         },
 
-        // Dynamic icon scale — 25% bigger min
+        // Dynamic icon scale — clamp between 24 and 44 based on host and subnet count
         topoIconRadius() {
-            if (!this.topoData) return 48;
+            if (!this.topoData) return 36;
             const hostCount = Object.keys(this.topoData.hosts || {}).length;
-            if (hostCount <= 3) return 56;
-            if (hostCount <= 6) return 52;
-            if (hostCount <= 12) return 48;
-            if (hostCount <= 20) return 44;
-            if (hostCount <= 35) return 40;
-            return 36;
+            const subnetCount = (this.topoData.subnets || []).length;
+            // Scale: 44 for ≤4 hosts, smoothly down to 24 for 20+ hosts
+            const byHosts = Math.max(24, Math.min(44, Math.round(52 - hostCount * 1.4)));
+            // Cap for few subnets so a single subnet doesn't produce giant icons
+            const bySubnets = Math.max(28, Math.min(44, 20 + subnetCount * 8));
+            return Math.min(byHosts, bySubnets);
         },
 
         topoIconImgSize() {
@@ -1574,15 +1674,17 @@ export default {
             if (!this.topoData) return 800;
             const subnets = this.topoSubnets;
             const lastSubnet = subnets[subnets.length - 1];
-            const w = lastSubnet ? lastSubnet.x + lastSubnet.w + 20 : 500;
-            return Math.max(w, 600);  // minimum width prevents huge icons
+            const contentW = lastSubnet ? lastSubnet.x + lastSubnet.w + 40 : 500;
+            // Ensure minimum width so icons don't dominate when few hosts/subnets
+            return Math.max(contentW, 800);
         },
 
         topoSvgHeight() {
             if (!this.topoData) return 300;
             const subnets = this.topoSubnets;
             const maxH = subnets.reduce((max, s) => Math.max(max, s.y + s.h + 20), 0);
-            return Math.max(maxH, 250);  // minimum height
+            // Ensure C2 icon (at y = svgH/2) plus its radius fits within bounds
+            return Math.max(maxH, 300);
         },
 
         topoOperationName() {
@@ -1698,8 +1800,14 @@ div
             span.topo-legend-dot(style="border: 2px dashed #FFB000")
             span Pivot
           span.topo-legend-item
+            span.topo-legend-dot.topo-legend-filled(style="background:#6688cc")
+            span Command
+          span.topo-legend-item
             span.topo-legend-dot.topo-legend-filled(style="background:#44AA99")
-            span Beacon
+            span Success
+          span.topo-legend-item
+            span.topo-legend-dot.topo-legend-filled(style="background:#CC3311")
+            span Failure
           span.topo-legend-item
             span.topo-legend-dot(style="border: 2px solid #555; color:#555; font-size:10px; display:flex; align-items:center; justify-content:center; width:14px; height:14px") ?
             span Discovered
@@ -1734,14 +1842,21 @@ div
                       :class="{ 'is-newest': topoNewestEdge === ei }",
                       fill="none"
                     )
-                    //- Green beacon — a single green dot that hops along the dashed path
+                    //- Command dot — C2 sending instruction to host (forward along edge)
+                    circle.topo-command-dot(
+                      v-if="topoCommandEdges.has(ei)",
+                      r="4", fill="#6688cc",
+                      :cx="topoCommandDotPos(ei).x",
+                      :cy="topoCommandDotPos(ei).y"
+                    )
+                    //- Beacon dot — host reporting back to C2 (reverse along edge), color = status
                     circle.topo-beacon-dot(
                       v-if="topoBeaconEdges.has(ei)",
-                      r="4", fill="#44AA99",
+                      r="4", :fill="topoBeaconDotColor",
                       :cx="topoBeaconDotPos(ei).x",
                       :cy="topoBeaconDotPos(ei).y"
                     )
-                    //- Red pulse: edge appearing (forward direction)
+                    //- Red pulse: edge appearing (first contact)
                     circle.topo-pulse(v-if="topoNewestEdge === ei", r="2", fill="#cc3311")
                       animateMotion(dur="0.5s", repeatCount="1", :path="edge.path")
               //- Host icons
@@ -1761,6 +1876,7 @@ div
                     //- Pivot indicator: dashed orange ring
                     circle.topo-pivot-ring(v-if="host.isPivot", :r="topoIconRadius + 4", fill="none", stroke="#FFB000", stroke-width="1.5", stroke-dasharray="4 3")
                     text.topo-host-label(:y="topoIconRadius + 22", text-anchor="middle") {{ host.hostname }}
+                    text.topo-host-ip(:y="topoIconRadius + 34", text-anchor="middle", font-size="9", fill="#aaa") {{ host.ips && host.ips.length ? '(' + host.ips[0] + ')' : '' }}
                     g.topo-badge(v-if="host.compromised && topoHostCurrentSteps(host.id) > 0")
                       circle(:cx="topoIconRadius - 4", :cy="-topoIconRadius + 4", r="7", fill="#4c0089")
                       text(:x="topoIconRadius - 4", :y="-topoIconRadius + 4", text-anchor="middle", dominant-baseline="central", fill="white", font-size="8") {{ topoHostCurrentSteps(host.id) }}
@@ -1950,6 +2066,10 @@ div
             p(v-else) Select a logo to see preview
         h5 Report Sections
         p.help Sections that are checked will be displayed in the report in order as shown in the list below.
+        .mb-2
+          button.button.is-small.is-dark(@click="selectAllReportSections") Select All
+          |
+          button.button.is-small.is-light.ml-2(@click="deselectAllReportSections") Deselect All
         table
           caption Sections to display in report
           thead


### PR DESCRIPTION
## Summary
- Overhaul topology replay UI with bidirectional traffic animation, dynamic sizing, and direct C2 edges
- Fix PDF attack path graph with inline vector OS icons, connection lines, and pivot rendering
- Remove broken D3 force-directed graphs from PDF, hide from section picker
- Rebalance table column widths and reduce padding across all PDF tables
- Move statistics to cover page, hide empty Step Output sections

## Test plan
- [x] 239 tests passing
- [x] PDF verified with 2-host operation (icons, edges, tables)
- [x] 6-host pivot topology test PDF renders correctly
- [x] Topology UI shows correct direct C2 connections
- [x] Replay animation shows command/beacon dots with status colors